### PR TITLE
Trivial fixes for xbmc.log under python2

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -6,6 +6,7 @@
 #  See LICENSES/README.md for more information.
 #
 
+import sys
 import urllib
 import urlparse
 
@@ -15,13 +16,20 @@ import xbmcaddon
 __addon__ = xbmcaddon.Addon()
 __addonid__ = __addon__.getAddonInfo('id')
 
+PY3 = sys.version_info.major >= 3
+
 def log(message, level=xbmc.LOGINFO):
-    xbmc.log('[{}] {}'.format(__addonid__, message.encode('utf-8')), level)
+    if not PY3:
+        try:
+            message = message.encode('utf-8')
+        except UnicodeDecodeError:
+            message = message.decode('utf-8').encode('utf-8', 'ignore')
+    xbmc.log('[{}] {}'.format(__addonid__, message), level)
 
 # fixes unicode problems
 def string2Unicode(text, encoding='utf-8'):
     try:
-        if sys.version_info[0] >= 3:
+        if PY3:
             text = str(text)
         else:
             text = unicode(text, encoding)


### PR DESCRIPTION
Hey montelesse,

I am one of those patiently waiting to get this feature on Kodi master. I gave it a try with your last build since I configured plex recently. Unfortunately I was not able to use the addon right away due to exceptions being triggered in your log function (hopefully when python3 is included all this unicode crap can finally go away). In this PR I send the changes I needed to make to have it working.

A few random notes I found while testing (since I don't know if some are known issues):

- I found it really easy to configure. My server was detected right away and I was able to import to the kodi database. 
- Items were marked as watched in plex server when I marked them as watched in kodi.
- Subtitles were not available to the player although the item contains subtitles in plex server
- Scroble/watch times were not synchronised to plex server.
- Rebasing on a version with python3 would be really nice. If you need help porting the addons just ping me.

Thanks a lot for your hard work on this!