### PR TITLE
Add support for external subtitles. Closes #11

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 [B]Version 0.0.4[/B]
--
+- Add support for external subtitles
 
 [B]Version 0.0.3[/B]
 - Support reporting playback progress / status to PMS

--- a/plex/constants.py
+++ b/plex/constants.py
@@ -85,6 +85,7 @@ SETTINGS_PROVIDER_LINK_MYPLEX_ACCOUNT = 'plex.linkmyplexaccount'
 SETTINGS_PROVIDER_USERNAME = 'plex.username'
 SETTINGS_PROVIDER_TOKEN = 'plex.token'
 SETTINGS_PROVIDER_TEST_CONNECTION = 'plex.testconnection'
+SETTINGS_PROVIDER_PLAYBACK_ENABLE_EXTERNAL_SUBTITLES = 'plex.enableexternalsubtitles'
 
 # media import setting identifiers and values
 SETTINGS_IMPORT_LIBRARY_SECTIONS = 'plex.librarysections'

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -140,3 +140,15 @@ msgstr ""
 msgctxt "#32061"
 msgid "Plex Media Server \"{}\" is only accessible via relay. Is that ok?"
 msgstr ""
+
+msgctxt "#32062"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#32063"
+msgid "Enable external subtitles"
+msgstr ""
+
+msgctxt "#32064"
+msgid "Unknown"
+msgstr ""

--- a/resources/providersettings.xml
+++ b/resources/providersettings.xml
@@ -61,5 +61,14 @@
         </setting>
       </group>
     </category>
+    <category id="playback" label="32062">
+      <group id="1">
+        <setting id="plex.enableexternalsubtitles" type="boolean" label="32063">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
   </section>
 </settings>


### PR DESCRIPTION
As the title says, this implements external subtitle support in the mediaimporter addon.
I tried to follow the same implementation you did in mediaimporter.emby. Luckily, the plexapi is a bit cleaner for getting external subs. The server object (`self._server`) is also a part of `self._item` however it is private to the class. As a result, I pass the server to the `addExternalSubtitles` method.