### PR TITLE
Do not abort the whole import process if a single item is broken on t…

### DIFF
--- a/lib/importer.py
+++ b/lib/importer.py
@@ -633,11 +633,17 @@ def execImport(handle, options):
             if xbmcmediaimport.shouldCancel(handle, itemsProgress, itemsProgressTotal):
                 return
 
-            item = Api.toFileItem(plexServer, plexItem, mediaType, plexLibType)
-            if not item:
-                continue
+            try:
+                item = Api.toFileItem(plexServer, plexItem, mediaType, plexLibType)
+                if not item:
+                    continue
 
-            items.append(item)
+                items.append(item)
+
+            except plexapi.exceptions.BadRequest as err:
+                # Api.convertDateTimeToDbDateTime may return (404) not_found for orphaned items in the library
+                log('failed to retrieve item {} with key {} from {}: {}'.format(plexItem.title, plexItem.key, mediaProvider2str(mediaProvider), err))
+                continue
 
         if items:
             log('{} {} items imported from {}'.format(len(items), mediaType, mediaProvider2str(mediaProvider)))


### PR DESCRIPTION
…he PMS side

-------

As the title reads, while importing a commons friend library the whole import process failed due to a single item broken on the PMS side. I don't really know the reason but looks like some issue of the server itself. Item appears on search but you get a 404 as soon as you try to get the item details. On the importer side, BadRequest exception is raised. After the fix, item is logged but the whole process continues:

```
x2020-02-03 15:58:32.262 T:18446744073709551615    INFO: [mediaimporter.plex] failed to retrieve item Ralph Breaks the Internet with key /library/metadata/144731 from "DC" (plex://3aa8eb3354bb34fb5b83de3x
c6b5761ebc28fe75b/): (404) not_found; https://removed-for-privary-reasons.plex.direct:32400/library/metadata/144731?checkFiles=1&includeExtras=1&includeRelated=1&includeOnDeck=1&includex
Chapters=1&includePopularLeaves=1&includeConcerts=1&includePreferences=1 <html><head><title>Not Found</title></head><body><h1>404 Not Found</h1></body></html>                                             x
x2020-02-03 15:58:34.628 T:18446744073709551615   DEBUG: ------ Window Deinit (Pointer.xml) ------
```

When kodi fails to import a library item, an event is shown in Event Manager. However, we don't have access to that interface from python right now (and in my opinion we shouldn't) so we can't simulate the same behaviour. Media importer could be extended to have a method to "sinalize" failed imports so that we call that from python and the event is generated. 
Extending the event interface to plugins may cause all sorts of abuse from python devs.