### PR TITLE
Fix MyPlex Linking, Docstrings, Type Annotations, Various PEP8 Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.idea/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -5,5 +5,15 @@
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSES/README.md for more information.
 #
+"""
+Package to facilitate interaction with the Kodi mediaimport system
+
+Modules:
+    discovery
+    importer
+    monitor
+    observer
+    utils
+"""
 
 from lib.utils import log

--- a/lib/importer.py
+++ b/lib/importer.py
@@ -50,7 +50,7 @@ import plexapi.exceptions
 from plexapi.myplex import MyPlexAccount, MyPlexPinLogin, MyPlexResource
 from plexapi.server import PlexServer
 
-from lib.utils import localize, log, mediaProvider2str
+from lib.utils import localize, log, mediaProvider2str, normalizeString
 import plex
 from plex.api import Api
 from plex.server import Server
@@ -236,7 +236,7 @@ def linkToMyPlexAccount() -> MyPlexAccount:
         return None
 
     # show the user the pin
-    dialog.ok(localize(32015), localize(32053), f"[COLOR FFE5A00D]{pinLogin.pin}[/COLOR]")
+    dialog.ok(localize(32015), localize(32053) + normalizeString(f" [COLOR FFE5A00D]{pinLogin.pin}[/COLOR]"))
 
     # check the status of the authentication
     while not pinLogin.finished:
@@ -334,7 +334,7 @@ def linkMyPlexAccount(handle: int, _options: dict):
         xbmcgui.Dialog().ok(localize(32015), localize(32058))
         return
 
-    xbmcgui.Dialog().ok(localize(32015), localize(32059).format(username))
+    xbmcgui.Dialog().ok(localize(32015), localize(32059, username))
 
     # change the settings
     providerSettings.setString(plex.constants.SETTINGS_PROVIDER_USERNAME, username)
@@ -434,7 +434,7 @@ def discoverProviderWithMyPlex(handle: int, _options: dict) -> xbmcmediaimport.M
 
         if localConnections:
             # ask the user whether to use a local or remote connection
-            isLocal = dialog.yesno(localize(32056), localize(32057).format(server.name))
+            isLocal = dialog.yesno(localize(32056), localize(32057, server.name))
 
         urls = []
         if isLocal:
@@ -459,7 +459,7 @@ def discoverProviderWithMyPlex(handle: int, _options: dict) -> xbmcmediaimport.M
 
                 # if this is a relay ask the user if using it is ok
                 if isRelay:
-                    connectViaRelay = dialog.yesno(localize(32056), localize(32061).format(server.name))
+                    connectViaRelay = dialog.yesno(localize(32056), localize(32061, server.name))
                     if not connectViaRelay:
                         log(
                             f"ignoring relay connection to the Plex Media Server '{server.name}' at {url}",
@@ -474,7 +474,7 @@ def discoverProviderWithMyPlex(handle: int, _options: dict) -> xbmcmediaimport.M
                 continue
 
         if not baseUrl:
-            dialog.ok(localize(32056), localize(32060).format(server.name))
+            dialog.ok(localize(32056), localize(32060, server.name))
             log(
                 f"failed to connect to the Plex Media Server '{server.name}' for MyPlex account {username}",
                 xbmc.LOGWARNING
@@ -731,7 +731,7 @@ def settingOptionsFillerLibrarySections(handle: int, _options: dict):
 
     server = Server(mediaProvider)
     if not server.Authenticate():
-        log('failed to connect to Plex Media Server for {}'.format(mediaProvider2str(mediaProvider)), xbmc.LOGWARNING)
+        log(f"failed to connect to Plex Media Server for {mediaProvider2str(mediaProvider)}", xbmc.LOGWARNING)
         return
 
     plexServer = server.PlexServer()
@@ -864,9 +864,9 @@ def execImport(handle: int, options: dict):
             continue
 
         plexLibType = mappedMediaType['libtype']
-        localizedMediaType = localize(mappedMediaType['label'])
+        localizedMediaType = localize(mappedMediaType['label']).decode()
 
-        xbmcmediaimport.setProgressStatus(handle, localize(32001).format(localizedMediaType))
+        xbmcmediaimport.setProgressStatus(handle, localize(32001, localizedMediaType))
 
         log(f"importing {mediaType} items from {mediaProvider2str(mediaProvider)}", xbmc.LOGINFO)
 

--- a/lib/monitor.py
+++ b/lib/monitor.py
@@ -9,5 +9,6 @@
 import xbmc
 
 class Monitor(xbmc.Monitor):
+    """Customization of the xbmc Monitor class for addon"""
     def __init__(self):
         xbmc.Monitor.__init__(self)

--- a/lib/observer.py
+++ b/lib/observer.py
@@ -6,18 +6,16 @@
 #  See LICENSES/README.md for more information.
 #
 
-import xbmc
 import xbmcmediaimport
 
 from lib.monitor import Monitor
 from lib.utils import log, mediaImport2str, mediaProvider2str
 
-import plex
 from plex.player import Player
 from plex.provider_observer import ProviderObserver
-from plex.server import Server
 
 class PlexObserverService(xbmcmediaimport.Observer):
+    """Class that handles observation of Plex servers for live updates"""
     def __init__(self):
         super(xbmcmediaimport.Observer, self).__init__()
 
@@ -28,6 +26,7 @@ class PlexObserverService(xbmcmediaimport.Observer):
         self._run()
 
     def _run(self):
+        """Begin observing configured Plex servers"""
         log('Observing Plex servers...')
 
         while not self._monitor.abortRequested():
@@ -45,7 +44,12 @@ class PlexObserverService(xbmcmediaimport.Observer):
         for observer in self._observers.values():
             observer.Stop()
 
-    def _addObserver(self, mediaProvider):
+    def _addObserver(self, mediaProvider: xbmcmediaimport.MediaProvider):
+        """Register a new observer (Plex server) in the observation process
+
+        :param mediaProvider: Plex Server MediaProvider object to observe
+        :type mediaProvider: :class:`xbmcmediaimport.MediaProvider`
+        """
         if not mediaProvider:
             raise ValueError('cannot add invalid media provider')
 
@@ -59,7 +63,12 @@ class PlexObserverService(xbmcmediaimport.Observer):
         # create the observer
         self._observers[mediaProviderId] = ProviderObserver()
 
-    def _removeObserver(self, mediaProvider):
+    def _removeObserver(self, mediaProvider: xbmcmediaimport.MediaProvider):
+        """Remove a registered observer (Plex sever) from the observation process
+
+        :param mediaProvider: Plex Server MediaProvider object to remove from observation
+        :type mediaProvider: :class:`xbmcmediaimport.MediaProvider`
+        """
         if not mediaProvider:
             raise ValueError('cannot remove invalid media provider')
 
@@ -71,7 +80,12 @@ class PlexObserverService(xbmcmediaimport.Observer):
 
         del self._observers[mediaProviderId]
 
-    def _startObserver(self, mediaProvider):
+    def _startObserver(self, mediaProvider: xbmcmediaimport.MediaProvider):
+        """Start observation on the provided MediaProvider (Plex server)
+
+        :param mediaProvider: Plex Server MediaProvider object to observe
+        :type mediaProvider: :class:`xbmcmediaimport.MediaProvider`
+        """
         if not mediaProvider:
             raise ValueError('cannot start invalid media provider')
 
@@ -81,7 +95,12 @@ class PlexObserverService(xbmcmediaimport.Observer):
         # start observing the media provider
         self._observers[mediaProvider.getIdentifier()].Start(mediaProvider)
 
-    def _stopObserver(self, mediaProvider):
+    def _stopObserver(self, mediaProvider: xbmcmediaimport.MediaProvider):
+        """Stp[ observation on the provided MediaProvider (Plex server)
+
+        :param mediaProvider: Plex Server MediaProvider object to stop observation of
+        :type mediaProvider: :class:`xbmcmediaimport.MediaProvider`
+        """
         if not mediaProvider:
             raise ValueError('cannot stop invalid media provider')
 
@@ -91,38 +110,58 @@ class PlexObserverService(xbmcmediaimport.Observer):
 
         self._observers[mediaProviderId].Stop()
 
-    def _addImport(self, mediaImport):
+    def _addImport(self, mediaImport: xbmcmediaimport.MediaImport):
+        """Add provided mediaImport task to the associated MediaProvider observer
+
+        :param mediaImport: MediaImport task to add to provider
+        :type mediaImport: :class:`xbmcmediaimport.MediaImport`
+        """
         if not mediaImport:
             raise ValueError('cannot add invalid media import')
 
         mediaProvider = mediaImport.getProvider()
         if not mediaProvider:
-            raise ValueError('cannot add media import {} with invalid media provider'.format(mediaImport2str(mediaImport)))
+            raise ValueError(f"cannot add media import {mediaImport2str(mediaImport)} with invalid media provider")
 
         mediaProviderId = mediaProvider.getIdentifier()
-        if not mediaProviderId in self._observers:
+        if mediaProviderId not in self._observers:
             return
 
         self._observers[mediaProviderId].AddImport(mediaImport)
 
-    def _removeImport(self, mediaImport):
+    def _removeImport(self, mediaImport: xbmcmediaimport.MediaImport):
+        """Remove provided mediaImport task to the associated MediaProvider observer
+
+        :param mediaImport: MediaImport task to remove from provider
+        :type mediaImport: :class:`xbmcmediaimport.MediaImport`
+        """
         if not mediaImport:
             raise ValueError('cannot remove invalid media import')
 
         mediaProvider = mediaImport.getProvider()
         if not mediaProvider:
-            raise ValueError('cannot remove media import {} with invalid media provider'.format(mediaImport2str(mediaImport)))
+            raise ValueError(f"cannot remove media import {mediaImport2str(mediaImport)} with invalid media provider")
 
         mediaProviderId = mediaProvider.getIdentifier()
-        if not mediaProviderId in self._observers:
+        if mediaProviderId not in self._observers:
             return
 
         self._observers[mediaProviderId].RemoveImport(mediaImport)
 
-    def onProviderAdded(self, mediaProvider):
+    def onProviderAdded(self, mediaProvider: xbmcmediaimport.MediaProvider):
+        """Event handler: triggered when a new provider is added to the system, register it as an observer
+
+        :param mediaProvider: MediaProvider that was added to the system
+        :type mediaProvider: :class:`xbmcmediaimport.MediaProvider`
+        """
         self._addObserver(mediaProvider)
 
-    def onProviderUpdated(self, mediaProvider):
+    def onProviderUpdated(self, mediaProvider: xbmcmediaimport.MediaProvider):
+        """Event handler: triggered when a provider is updated in the system, make sure it is being observed
+
+        :param mediaProvider: MediaProvider that was added to the system
+        :type mediaProvider: :class:`xbmcmediaimport.MediaProvider`
+        """
         self._addObserver(mediaProvider)
 
         # make sure the media provider is being observed
@@ -131,20 +170,50 @@ class PlexObserverService(xbmcmediaimport.Observer):
         else:
             self._stopObserver(mediaProvider)
 
-    def onProviderRemoved(self, mediaProvider):
+    def onProviderRemoved(self, mediaProvider: xbmcmediaimport.MediaProvider):
+        """Event handler: triggered when a provider is removed from the system, remove from observation
+
+        :param mediaProvider: MediaProvider that was removed from the system
+        :type mediaProvider: :class:`xbmcmediaimport.MediaProvider`
+        """
         self._removeObserver(mediaProvider)
 
-    def onProviderActivated(self, mediaProvider):
+    def onProviderActivated(self, mediaProvider: xbmcmediaimport.MediaProvider):
+        """Event handler: triggered when a provider is actived in the system, start observation
+
+        :param mediaProvider: MediaProvider that was actived in the system
+        :type mediaProvider: :class:`xbmcmediaimport.MediaProvider`
+        """
         self._startObserver(mediaProvider)
 
-    def onProviderDeactivated(self, mediaProvider):
+    def onProviderDeactivated(self, mediaProvider: xbmcmediaimport.MediaProvider):
+        """Event handler: triggered when a provider is deactived in the system, remove from observation
+
+        :param mediaProvider: MediaProvider that was deactived in the system
+        :type mediaProvider: :class:`xbmcmediaimport.MediaProvider`
+        """
         self._stopObserver(mediaProvider)
 
-    def onImportAdded(self, mediaImport):
+    def onImportAdded(self, mediaImport: xbmcmediaimport.MediaImport):
+        """Event handler: triggered when a new import task is added to the system, add to media provider
+
+        :param mediaImport: MediaImport task added to the system
+        :type mediaImport: :class:`xbmcmediaimport.MediaImport`
+        """
         self._addImport(mediaImport)
 
-    def onImportUpdated(self, mediaImport):
+    def onImportUpdated(self, mediaImport: xbmcmediaimport.MediaImport):
+        """Event handler: triggered when a new import task is updated in the system, update in media provider
+
+        :param mediaImport: MediaImport task updated in the system
+        :type mediaImport: :class:`xbmcmediaimport.MediaImport`
+        """
         self._addImport(mediaImport)
 
-    def onImportRemoved(self, mediaImport):
+    def onImportRemoved(self, mediaImport: xbmcmediaimport.MediaImport):
+        """Event handler: triggered when a new import task is removed from the system, remove from media provider
+
+        :param mediaImport: MediaImport task removed from the system
+        :type mediaImport: :class:`xbmcmediaimport.MediaImport`
+        """
         self._removeImport(mediaImport)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -88,15 +88,18 @@ def normalizeString(text: str) -> bytes:
     return text
 
 
-def localize(id: int) -> bytes:
+def localize(id: int, format_input: str = "") -> bytes:
     """Helper function to pull localized strings from language resources
 
     :param id: ID of the string to pull from the resource database
     :type id: int
+    :param format_input: String to .format into the localized string before encoding
+    :type format_input: str, optional
     :return: Localized and normalized byte string
     :rtype: bytes
     """
-    return normalizeString(__addon__.getLocalizedString(id))
+    local_string = __addon__.getLocalizedString(id)
+    return normalizeString(local_string.format(format_input))
 
 
 def toMilliseconds(seconds: float) -> int:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -5,29 +5,62 @@
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSES/README.md for more information.
 #
+"""
+Collection of utility functions and classes for logging, data conversion, etc.
 
-import sys
+Functions:
+    log
+    string2Unicode
+    nomalizeString
+    localise
+    toMilliseconds
+    mediaProvider2str
+    mediaImport2str
+
+Classes:
+    Url
+"""
+
 from six import PY3
 from six.moves.urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+import unicodedata
 
 import xbmc
 import xbmcaddon
+import xbmcmediaimport
 
 __addon__ = xbmcaddon.Addon()
 __addonid__ = __addon__.getAddonInfo('id')
 
 
-def log(message, level=xbmc.LOGINFO):
+def log(message: str, level: int = xbmc.LOGINFO):
+    """Log function to send logs into the Kodi log system
+
+    :param message: Log message to send to Kodi
+    :type message: str
+    :param level: Kodi log level (LOGNONE, LOGDEBUG, *LOGINFO, LOGNOTICE, LOGWARNING, LOGERROR, LOGSEVERE, LOGFATAL)
+    :type level: int, optional
+    """
     if not PY3:
         try:
             message = message.encode('utf-8')
         except UnicodeDecodeError:
             message = message.decode('utf-8').encode('utf-8', 'ignore')
-    xbmc.log('[{}] {}'.format(__addonid__, message), level)
+
+    xbmc.log(f"[{__addonid__}] {message}", level)
 
 
 # fixes unicode problems
-def string2Unicode(text, encoding='utf-8'):
+def string2Unicode(text: str, encoding: str = 'utf-8') -> str:
+    """Helper function for encoding strings
+
+    :param text: String of text to encode
+    :type text: str
+    :param encoding: The type of encoding to use, defaults to 'utf-8'
+    :type encoding: str, optional
+    :return: Encoded text
+    :rtype: str
+    """
     try:
         if PY3:
             text = str(text)
@@ -39,7 +72,14 @@ def string2Unicode(text, encoding='utf-8'):
     return text
 
 
-def normalizeString(text):
+def normalizeString(text: str) -> bytes:
+    """Helper function to normaize a string of text to ascii bytestring
+
+    :param text:
+    :type text: str
+    :return: Normalized/encoded string of ascii text
+    :rtype: bytes
+    """
     try:
         text = unicodedata.normalize('NFKD', string2Unicode(text)).encode('ascii', 'ignore')
     except:
@@ -48,53 +88,82 @@ def normalizeString(text):
     return text
 
 
-def localise(id):
+def localize(id: int) -> bytes:
+    """Helper function to pull localized strings from language resources
+
+    :param id: ID of the string to pull from the resource database
+    :type id: int
+    :return: Localized and normalized byte string
+    :rtype: bytes
+    """
     return normalizeString(__addon__.getLocalizedString(id))
 
 
-def toMilliseconds(seconds):
+def toMilliseconds(seconds: float) -> int:
+    """Helper function to convert seconds(float) to milliseconds(int)
+
+    :param seconds: Time in seconds
+    :type seconds: float
+    :return: Time in milliseconds
+    :rtype: int
+    """
     return int(seconds) * 1000
 
 
-def mediaProvider2str(mediaProvider):
+def mediaProvider2str(mediaProvider: xbmcmediaimport.MediaProvider):
+    """Helper function to convert a MediaProvider object into a string for logging
+
+    :param mediaProvider: MediaProvider to convert into a string
+    :type mediaProvider: :class:`xbmcmediaimport.MediaProvider`
+    :return: String representing the MediaProvider for logs
+    :rtype: str
+    """
     if not mediaProvider:
         raise ValueError('invalid mediaProvider')
 
-    return '"{}" ({})'.format(mediaProvider.getFriendlyName(), mediaProvider.getIdentifier())
+    return f"'{mediaProvider.getFriendlyName()}' ({mediaProvider.getIdentifier()})"
 
 
-def mediaImport2str(mediaImport):
+def mediaImport2str(mediaImport: xbmcmediaimport.MediaImport):
+    """Helper function to convert a MediaImport object into a string for logging
+
+    :param mediaImport: MediaImport to convert into a string
+    :type mediaImport: :class:`xbmcmediaimport.MediaImport`
+    :return: String representing the MediaImport for logs
+    :rtype: str
+    """
     if not mediaImport:
         raise ValueError('invalid mediaImport')
 
-    return '{} ({})'.format(mediaImport.getPath(), mediaImport.getMediaTypes())
+    return f"{mediaImport.getPath()} ({mediaImport.getMediaTypes()})"
 
-
-class Url:
-    @staticmethod
-    def append(url, *args):
-        if not url:
-            return ''
-
-        # remove a potentially trailing slash
-        if url.endswith('/'):
-            url = url[:-1]
-
-        for arg in args:
-            if not arg.startswith('/'):
-                url += '/'
-
-            url += arg
-
-        return url
-
-    @staticmethod
-    def addOptions(url, options):
-        if not url:
-            return ''
-
-        urlParts = list(urlparse(url))
-        urlQuery = dict(parse_qsl(urlParts[4]))
-        urlQuery.update(options)
-        urlParts[4] = urlencode(urlQuery)
-        return urlunparse(urlParts)
+# Commenting out for now, not used in the project anywwhere
+#
+# class Url:
+#     @staticmethod
+#     def append(url, *args):
+#         if not url:
+#             return ''
+#
+#         # remove a potentially trailing slash
+#         if url.endswith('/'):
+#             url = url[:-1]
+#
+#         for arg in args:
+#             if not arg.startswith('/'):
+#                 url += '/'
+#
+#             url += arg
+#
+#         return url
+#
+#     @staticmethod
+#     def addOptions(url, options):
+#         if not url:
+#             return ''
+#
+#         urlParts = list(urlparse(url))
+#         urlQuery = dict(parse_qsl(urlParts[4]))
+#         urlQuery.update(options)
+#         urlParts[4] = urlencode(urlQuery)
+#         return urlunparse(urlParts)

--- a/plex/__init__.py
+++ b/plex/__init__.py
@@ -5,8 +5,20 @@
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSES/README.md for more information.
 #
+"""
+Package to facilitate interaction with Plex and Kodi for the addon.
 
-def Initialize():
+Modules:
+    api
+    constants
+    player
+    provider_observer
+    server
+"""
+
+
+def Initialize() -> None:
+    """Initialize the package by setting some base variables in the plexapi"""
     import xbmc
 
     import plexapi

--- a/plex/constants.py
+++ b/plex/constants.py
@@ -5,13 +5,21 @@
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSES/README.md for more information.
 #
+"""
+Various constant variables used by the plex library.
+"""
 
 import xbmcmediaimport
 
 # import related constants
-SUPPORTED_MEDIA_TYPES = set([ xbmcmediaimport.MediaTypeMovie, xbmcmediaimport.MediaTypeVideoCollection,
+SUPPORTED_MEDIA_TYPES = {
+    xbmcmediaimport.MediaTypeMovie,
+    xbmcmediaimport.MediaTypeVideoCollection,
     xbmcmediaimport.MediaTypeMusicVideo,
-    xbmcmediaimport.MediaTypeTvShow, xbmcmediaimport.MediaTypeSeason, xbmcmediaimport.MediaTypeEpisode ])
+    xbmcmediaimport.MediaTypeTvShow,
+    xbmcmediaimport.MediaTypeSeason,
+    xbmcmediaimport.MediaTypeEpisode
+}
 
 # API related constants
 REQUEST_TIMEOUT = 5
@@ -64,7 +72,6 @@ WS_MESSAGE_NOTIFICATION_ACTIVITY_EVENT = 'event'
 # WS_MESSAGE_NOTIFICATION_ACTIVITY_EVENT_STARTED = 'started'
 # WS_MESSAGE_NOTIFICATION_ACTIVITY_EVENT_UPDATED = 'updated'
 WS_MESSAGE_NOTIFICATION_ACTIVITY_EVENT_ENDED = 'ended'
-WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY = 'Activity'
 WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_TYPE = 'type'
 WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_TYPE_REFRESH_ITEMS = 'library.refresh.items'
 WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_CONTEXT = 'Context'

--- a/plex/player.py
+++ b/plex/player.py
@@ -26,7 +26,7 @@ from lib.utils import log, mediaProvider2str, toMilliseconds, localize
 
 REPORTING_INTERVAL = 5  # seconds
 
-SUBTITLE_UNKNOWN = localize(32064)
+SUBTITLE_UNKNOWN = localize(32064).decode()
 
 
 class Player(xbmc.Player):

--- a/plex/provider_observer.py
+++ b/plex/provider_observer.py
@@ -21,14 +21,14 @@ from plex.server import Server
 
 from lib.utils import log, mediaImport2str, mediaProvider2str
 
-ENDPOINT = '/:/websockets/notifications'
-
 
 class ProviderObserver:
     """Class for observing the PMS websocket stream for live updates and processing the messages."""
     class Action:
         Start = 0
         Stop = 1
+
+    ENDPOINT = '/:/websockets/notifications'
 
     def __init__(self):
         # default values
@@ -93,7 +93,6 @@ class ProviderObserver:
             raise ValueError('invalid mediaProvider')
 
         self._actions.append((ProviderObserver.Action.Start, mediaProvider))
-        log(f"started observation of {mediaProvider.friendlyName}", xbmc.LOGINFO)
 
     def Stop(self):
         """End all observation tasks"""

--- a/plex/provider_observer.py
+++ b/plex/provider_observer.py
@@ -7,23 +7,28 @@
 #
 
 import json
+from typing import List
 import websocket
 
+import plexapi
 import xbmc
+import xbmcgui
 import xbmcmediaimport
 
-from plex.api import *
-from plex.constants import *
+import plex.api as api
+import plex.constants as constants
 from plex.server import Server
 
-from lib.utils import log, mediaImport2str, mediaProvider2str, Url
+from lib.utils import log, mediaImport2str, mediaProvider2str
+
+ENDPOINT = '/:/websockets/notifications'
+
 
 class ProviderObserver:
+    """Class for observing the PMS websocket stream for live updates and processing the messages."""
     class Action:
         Start = 0
         Stop = 1
-
-    ENDPOINT = '/:/websockets/notifications'
 
     def __init__(self):
         # default values
@@ -40,7 +45,12 @@ class ProviderObserver:
     def __del__(self):
         self._StopAction()
 
-    def AddImport(self, mediaImport):
+    def AddImport(self, mediaImport: xbmcmediaimport.MediaImport):
+        """Add, or update if existing, mediaImport into list of imports
+
+        :param mediaImport: mediaImport object to update into the import list
+        :type mediaImport: :class:`xbmcmediaimport.MediaImport`
+        """
         if not mediaImport:
             raise ValueError('invalid mediaImport')
 
@@ -49,13 +59,18 @@ class ProviderObserver:
         # if a matching import has been found update it
         if matchingImportIndices:
             self._imports[matchingImportIndices[0]] = mediaImport
-            log('media import {} updated'.format(mediaImport2str(mediaImport)))
+            log(f"media import {mediaImport2str(mediaImport)} updated", xbmc.LOGINFO)
         else:
             # other add the import to the list
             self._imports.append(mediaImport)
-            log('media import {} added'.format(mediaImport2str(mediaImport)))
+            log(f"media import {mediaImport2str(mediaImport)} added", xbmc.LOGINFO)
 
-    def RemoveImport(self, mediaImport):
+    def RemoveImport(self, mediaImport: xbmcmediaimport.MediaImport):
+        """Remove an existing mediaImport from the list of imports
+
+        :param mediaImport: mediaImport object to remove from the import plist
+        :type mediaImport: :class:`xbmcmediaimport.MediaImport`
+        """
         if not mediaImport:
             raise ValueError('invalid mediaImport')
 
@@ -66,42 +81,62 @@ class ProviderObserver:
 
         # remove the media import from the list
         del self._imports[matchingImportIndices[0]]
-        log('media import {} removed'.format(mediaImport2str(mediaImport)))
+        log(f"media import {mediaImport2str(mediaImport)} removed", xbmc.LOGINFO)
 
-    def Start(self, mediaProvider):
+    def Start(self, mediaProvider: xbmcmediaimport.MediaProvider):
+        """Trigger start of observation for the provided mediaProvider
+
+        :param mediaProvider: Media provider to start observing
+        :type mediaProvider: :class:`xbmcmediaimport.MediaProvider`
+        """
         if not mediaProvider:
             raise ValueError('invalid mediaProvider')
 
         self._actions.append((ProviderObserver.Action.Start, mediaProvider))
+        log(f"started observation of {mediaProvider.friendlyName}", xbmc.LOGINFO)
 
     def Stop(self):
+        """End all observation tasks"""
         self._actions.append((ProviderObserver.Action.Stop, None))
 
     def Process(self):
+        """Main trigger to process all queued messages and provider actions"""
         # process any open actions
         self._ProcessActions()
         # process any incoming messages
         self._ProcessMessages()
 
-    def _FindImportIndices(self, mediaImport):
+    def _FindImportIndices(self, mediaImport: xbmcmediaimport.MediaImport) -> List[int]:
+        """Find the list index for the provided mediaImport object in the imports list if present
+
+        :param mediaImport: The mediaImport object to find in the imports list
+        :type mediaImport: :class:`xbmcmediaimport.MediaImport`
+        :return: List of indexes where the mediaImport object was found
+        :rtype: list
+        """
         if not mediaImport:
             raise ValueError('invalid mediaImport')
 
-        return [ i for i, x in enumerate(self._imports) if x.getPath() == mediaImport.getPath() and x.getMediaTypes() == mediaImport.getMediaTypes() ]
+        return [
+            i for i, x in enumerate(self._imports)
+            if x.getPath() == mediaImport.getPath() and x.getMediaTypes() == mediaImport.getMediaTypes()
+        ]
 
     def _ProcessActions(self):
+        """Process pending provider actions in the queue (start/stop observation)"""
         for (action, data) in self._actions:
             if action == ProviderObserver.Action.Start:
                 self._StartAction(data)
             elif action == ProviderObserver.Action.Stop:
                 self._StopAction()
             else:
-                log('unknown action {} to process'.format(action), xbmc.LOGWARNING)
+                log(f"unknown action {action} to process", xbmc.LOGWARNING)
 
         self._actions = []
 
     def _ProcessMessages(self):
-        # nothing to do if we are not connected to an Emby server
+        """Trigger processing of messages from the media providers websocket"""
+        # nothing to do if we are not connected to a Plex server
         if not self._connected:
             return
 
@@ -113,83 +148,131 @@ class ProviderObserver:
 
                 messageObj = json.loads(message)
                 if not messageObj:
-                    log('invalid JSON message ({}) from {} received: {}'.format(len(message), mediaProvider2str(self._mediaProvider), message), xbmc.LOGWARNING)
+                    log(
+                        (
+                            f"invalid JSON message ({len(message)}) from {mediaProvider2str(self._mediaProvider)} "
+                            f"received: {message}"
+                        ),
+                        xbmc.LOGWARNING
+                    )
                     continue
 
                 self._ProcessMessage(messageObj)
 
             except websocket.WebSocketTimeoutException:
                 break
-            except Exception as error:
-                log('unknown exception when receiving data from {}: {}'.format(mediaProvider2str(self._mediaProvider), error.args[0]), xbmc.LOGWARNING)
+            except Exception as e:
+                log(
+                    f"unknown exception when receiving data from {mediaProvider2str(self._mediaProvider)}: {e.args[0]}",
+                    xbmc.LOGWARNING
+                )
                 break
 
-    def _ProcessMessage(self, message):
+    def _ProcessMessage(self, message: dict):
+        """Determine message type and pass to appropriate processing function
+
+        :param message: Message data to be processed
+        :type message: dict
+        """
         if not message:
             return
 
-        if not WS_MESSAGE_NOTIFICATION_CONTAINER in message:
-            log('message without "{}" received from {}: {}'.format(WS_MESSAGE_NOTIFICATION_CONTAINER, mediaProvider2str(self._mediaProvider), json.dumps(message)), xbmc.LOGWARNING)
+        if constants.WS_MESSAGE_NOTIFICATION_CONTAINER not in message:
+            log(
+                (
+                    f"message without '{constants.WS_MESSAGE_NOTIFICATION_CONTAINER}'"
+                    f"received from {mediaProvider2str(self._mediaProvider)}: {json.dumps(message)}"
+                ),
+                xbmc.LOGWARNING
+            )
             return
 
-        messageData = message[WS_MESSAGE_NOTIFICATION_CONTAINER]
-        if not WS_MESSAGE_NOTIFICATION_TYPE in messageData:
-            log('message without "{}" received from {}: {}'.format(WS_MESSAGE_NOTIFICATION_TYPE, mediaProvider2str(self._mediaProvider), json.dumps(message)), xbmc.LOGWARNING)
+        messageData = message[constants.WS_MESSAGE_NOTIFICATION_CONTAINER]
+        if constants.WS_MESSAGE_NOTIFICATION_TYPE not in messageData:
+            log(
+                (
+                    f"message without '{constants.WS_MESSAGE_NOTIFICATION_TYPE}'"
+                    f"received from {mediaProvider2str(self._mediaProvider)}: {json.dumps(message)}"
+                ),
+                xbmc.LOGWARNING
+            )
             return
 
-        messageType = messageData[WS_MESSAGE_NOTIFICATION_TYPE]
-        if messageType == WS_MESSAGE_NOTIFICATION_TYPE_TIMELINE:
+        messageType = messageData[constants.WS_MESSAGE_NOTIFICATION_TYPE]
+        if messageType == constants.WS_MESSAGE_NOTIFICATION_TYPE_TIMELINE:
             self._ProcessMessageTimelineEntry(messageData)
-        elif messageType == WS_MESSAGE_NOTIFICATION_TYPE_PLAYING:
+        elif messageType == constants.WS_MESSAGE_NOTIFICATION_TYPE_PLAYING:
             self._ProcessMessagePlaySessionState(messageData)
-        elif messageType == WS_MESSAGE_NOTIFICATION_TYPE_ACTIVITY:
+        elif messageType == constants.WS_MESSAGE_NOTIFICATION_TYPE_ACTIVITY:
             self._ProcessMessageActivity(messageData)
         else:
-            log('ignoring "{}" message from {}: {}'.format(messageType, mediaProvider2str(self._mediaProvider), json.dumps(message)), xbmc.LOGDEBUG)
+            log(
+                f"ignoring '{messageType}' from {mediaProvider2str(self._mediaProvider)}: {json.dumps(message)}",
+                xbmc.LOGWARNING
+            )
 
-    def _ProcessMessageTimelineEntry(self, data):
-        if not WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY in data:
-            log('invalid timeline message received from {}: {}'.format(mediaProvider2str(self._mediaProvider), json.dumps(data)), xbmc.LOGWARNING)
+    def _ProcessMessageTimelineEntry(self, data: dict):
+        """Gather details from a Timeline Entry message, format into a plex change and trigger further processing
+
+        :param data: Timeline message data to process
+        :type data: dict
+        """
+        if constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY not in data:
+            log(
+                f"invalid timeline message received from {mediaProvider2str(self._mediaProvider)}: {json.dumps(data)}",
+                xbmc.LOGWARNING
+            )
             return
 
-        timelineEntries = data[WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY]
+        timelineEntries = data[constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY]
         if not timelineEntries:
             return
 
+        required_keys = (
+            constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_IDENTIFIER,
+            constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_ITEM_ID,
+            constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_TYPE,
+            constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_STATE
+        )
+
         changedPlexItems = []
         for timelineEntry in timelineEntries:
-            if not all(key in timelineEntry for key in (WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_IDENTIFIER, WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_ITEM_ID, WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_TYPE, WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_STATE)):
+            if not all(key in timelineEntry for key in required_keys):
                 continue
 
             # we are only interested in library changes
-            if timelineEntry[WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_IDENTIFIER] != WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_IDENTIFIER_LIBRARY:
+            if (
+                    timelineEntry[constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_IDENTIFIER]
+                    != constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_IDENTIFIER_LIBRARY
+            ):
                 continue
 
-            plexItemId = int(timelineEntry[WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_ITEM_ID])
+            plexItemId = int(timelineEntry[constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_ITEM_ID])
             if not plexItemId:
                 continue
 
             # filter and determine the changed item's library type / class
-            plexItemType = timelineEntry[WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_TYPE]
-            if plexItemType == WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_TYPE_MOVIE:
-                plexItemLibraryType = PLEX_LIBRARY_TYPE_MOVIE
-            elif plexItemType == WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_TYPE_TVSHOW:
-                plexItemLibraryType = PLEX_LIBRARY_TYPE_TVSHOW
-            elif plexItemType == WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_TYPE_SEASON:
-                plexItemLibraryType = PLEX_LIBRARY_TYPE_SEASON
-            elif plexItemType == WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_TYPE_EPISODE:
-                plexItemLibraryType = PLEX_LIBRARY_TYPE_EPISODE
+            plexItemType = timelineEntry[constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_TYPE]
+            if plexItemType == constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_TYPE_MOVIE:
+                plexItemLibraryType = api.PLEX_LIBRARY_TYPE_MOVIE
+            elif plexItemType == constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_TYPE_TVSHOW:
+                plexItemLibraryType = api.PLEX_LIBRARY_TYPE_TVSHOW
+            elif plexItemType == constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_TYPE_SEASON:
+                plexItemLibraryType = api.PLEX_LIBRARY_TYPE_SEASON
+            elif plexItemType == constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_TYPE_EPISODE:
+                plexItemLibraryType = api.PLEX_LIBRARY_TYPE_EPISODE
             else:
                 continue
-            plexItemMediaClass = Api.getPlexMediaClassFromLibraryType(plexItemLibraryType)
+
+            plexItemMediaClass = api.Api.getPlexMediaClassFromLibraryType(plexItemLibraryType)
 
             # filter and process the changed item's state
-            plexItemState = timelineEntry[WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_STATE]
-            if plexItemState == WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_STATE_CREATED:
+            plexItemState = timelineEntry[constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_STATE]
+            if plexItemState == constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_STATE_CREATED:
                 plexItemChangesetType = xbmcmediaimport.MediaImportChangesetTypeAdded
-            elif plexItemState == WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_STATE_FINISHED:
+            elif plexItemState == constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_STATE_FINISHED:
                 plexItemChangesetType = xbmcmediaimport.MediaImportChangesetTypeChanged
-            elif plexItemState == WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_STATE_DELETED:
+            elif plexItemState == constants.WS_MESSAGE_NOTIFICATION_TIMELINE_ENTRY_STATE_DELETED:
                 plexItemChangesetType = xbmcmediaimport.MediaImportChangesetTypeRemoved
             else:
                 continue
@@ -198,12 +281,22 @@ class ProviderObserver:
 
         self._ProcessChangedPlexItems(changedPlexItems)
 
-    def _ProcessMessagePlaySessionState(self, data):
-        if not WS_MESSAGE_NOTIFICATION_PLAY_SESSION_STATE in data:
-            log('invalid playing message received from {}: {}'.format(mediaProvider2str(self._mediaProvider), json.dumps(data)), xbmc.LOGWARNING)
+    def _ProcessMessagePlaySessionState(self, data: dict):
+        """
+        Gather details from a Play Session message, format into a plex change and trigger further processing
+        Not Implemented
+
+        :param data: Play Session message data to process
+        :type data: dict
+        """
+        if constants.WS_MESSAGE_NOTIFICATION_PLAY_SESSION_STATE not in data:
+            log(
+                f"invalid playing message received from {mediaProvider2str(self._mediaProvider)}: {json.dumps(data)}",
+                xbmc.LOGWARNING
+            )
             return
 
-        playSessionStates = data[WS_MESSAGE_NOTIFICATION_PLAY_SESSION_STATE]
+        playSessionStates = data[constants.WS_MESSAGE_NOTIFICATION_PLAY_SESSION_STATE]
         if not playSessionStates:
             return
 
@@ -211,76 +304,121 @@ class ProviderObserver:
             # TODO(Montellese)
             pass
 
-    def _ProcessMessageActivity(self, data):
-        if not WS_MESSAGE_NOTIFICATION_ACTIVITY in data:
-            log('invalid activity message received from {}: {}'.format(mediaProvider2str(self._mediaProvider), json.dumps(data)), xbmc.LOGWARNING)
+    def _ProcessMessageActivity(self, data: dict):
+        """Gather details from an Activity message, format into a plex change and trigger further processing
+
+        :param data: Activity message data to process
+        :type data: dict
+        """
+        if constants.WS_MESSAGE_NOTIFICATION_ACTIVITY not in data:
+            log(
+                f"invalid activity message received from {mediaProvider2str(self._mediaProvider)}: {json.dumps(data)}",
+                xbmc.LOGWARNING
+            )
             return
 
-        activities = data[WS_MESSAGE_NOTIFICATION_ACTIVITY]
+        activities = data[constants.WS_MESSAGE_NOTIFICATION_ACTIVITY]
         if not activities:
             return
 
+        required_activity_keys = (
+            constants.WS_MESSAGE_NOTIFICATION_ACTIVITY_EVENT,
+            constants.WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY
+        )
+        required_activity_details_keys = (
+            constants.WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_TYPE,
+            constants.WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_CONTEXT
+        )
+
         changedPlexItems = []
         for activity in activities:
-            if not all(key in activity for key in (WS_MESSAGE_NOTIFICATION_ACTIVITY_EVENT, WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY)):
+            if not all(key in activity for key in required_activity_keys):
                 continue
             # we are only interested in the final result
-            if activity[WS_MESSAGE_NOTIFICATION_ACTIVITY_EVENT] != WS_MESSAGE_NOTIFICATION_ACTIVITY_EVENT_ENDED:
+            if (
+                    activity[constants.WS_MESSAGE_NOTIFICATION_ACTIVITY_EVENT]
+                    != constants.WS_MESSAGE_NOTIFICATION_ACTIVITY_EVENT_ENDED
+            ):
                 continue
 
-            activityDetails = activity[WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY]
-            if not all(key in activityDetails for key in (WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_TYPE, WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_CONTEXT)):
+            activityDetails = activity[constants.WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY]
+            if not all(key in activityDetails for key in required_activity_details_keys):
                 continue
 
             # we are only interested in changes to library items
-            if activityDetails[WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_TYPE] != WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_TYPE_REFRESH_ITEMS:
+            if (
+                    activityDetails[constants.WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_TYPE]
+                    != constants.WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_TYPE_REFRESH_ITEMS
+            ):
                 continue
 
-            context = activityDetails[WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_CONTEXT]
-            if not WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_CONTEXT_KEY in context:
+            context = activityDetails[constants.WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_CONTEXT]
+            if constants.WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_CONTEXT_KEY not in context:
                 continue
 
-            plexItemKey = context[WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_CONTEXT_KEY]
-            plexItemId = Api.getItemIdFromPlexKey(plexItemKey)
+            plexItemKey = context[constants.WS_MESSAGE_NOTIFICATION_ACTIVITY_ACTIVITY_CONTEXT_KEY]
+            plexItemId = api.Api.getItemIdFromPlexKey(plexItemKey)
             if not plexItemId:
                 continue
+
             changedPlexItems.append((xbmcmediaimport.MediaImportChangesetTypeChanged, plexItemId, None))
 
         self._ProcessChangedPlexItems(changedPlexItems)
 
-    def _ProcessChangedPlexItems(self, changedPlexItems):
+    def _ProcessChangedPlexItems(self, changedPlexItems: List[tuple]):
+        """
+        Determine if change was an add/update or remove operation,
+        pull the details of the item being changed,
+        format and trigger further processing
+
+        :param changedPlexItems: List of plex change tuples parsed from websocket messages to process
+        :type changedPlexItems: list
+        """
         changedItems = []
         for (changesetType, plexItemId, plexItemClass) in changedPlexItems:
             item = None
-            if changesetType == xbmcmediaimport.MediaImportChangesetTypeAdded or \
-               changesetType == xbmcmediaimport.MediaImportChangesetTypeChanged:
+            if (
+                    changesetType == xbmcmediaimport.MediaImportChangesetTypeAdded
+                    or changesetType == xbmcmediaimport.MediaImportChangesetTypeChanged
+            ):
                 # get all details for the added / changed item
                 item = self._GetItemDetails(plexItemId, plexItemClass)
                 if not item:
-                    log('failed to get details for changed item with id {}'.format(plexItemId), xbmc.LOGWARNING)
+                    log(f"failed to get details for changed item with id {plexItemId}", xbmc.LOGWARNING)
                     continue
             else:
                 # find the removed item in the list of imported items
                 importedItems = xbmcmediaimport.getImportedItemsByProvider(self._mediaProvider)
-                matchingItems = [ importedItem for importedItem in importedItems if Api.getItemIdFromListItem(importedItem) == plexItemId ]
+                matchingItems = [
+                    importedItem for importedItem in importedItems
+                    if api.Api.getItemIdFromListItem(importedItem) == plexItemId
+                ]
                 if not matchingItems:
-                    log('failed to find removed item with id {}'.format(plexItemId), xbmc.LOGWARNING)
+                    log(f"failed to find removed item with id {plexItemId}", xbmc.LOGWARNING)
                     continue
                 if len(matchingItems) > 1:
-                    log('multiple imported items for item with id {} found => only removing the first one'.format(plexItemId), xbmc.LOGWARNING)
+                    log(
+                        f"multiple imported items for item with id {plexItemId} found => only removing the first one",
+                        xbmc.LOGWARNING
+                    )
 
                 item = matchingItems[0]
 
             if not item:
-                log('failed to process changed item with id {}'.format(plexItemId), xbmc.LOGWARNING)
+                log(f"failed to process changed item with id {plexItemId}", xbmc.LOGWARNING)
                 continue
 
             changedItems.append((changesetType, item, plexItemId))
 
         self._ChangeItems(changedItems)
 
-    def _ChangeItems(self, changedItems):
-         # map the changed items to their media import
+    def _ChangeItems(self, changedItems: List[tuple]):
+        """Send change details to Kodi to perform library updates
+
+        :param changedItems: List of change detail tuples to process
+        :type changedItems: list
+        """
+        # map the changed items to their media import
         changedItemsMap = {}
         for (changesetType, item, plexItemId) in changedItems:
             if not item:
@@ -289,7 +427,7 @@ class ProviderObserver:
             # find a matching import for the changed item
             mediaImport = self._FindImportForItem(item)
             if not mediaImport:
-                log('failed to determine media import for changed item with id {}'.format(plexItemId), xbmc.LOGWARNING)
+                log(f"failed to determine media import for changed item with id {plexItemId}", xbmc.LOGWARNING)
                 continue
 
             if mediaImport not in changedItemsMap:
@@ -300,33 +438,65 @@ class ProviderObserver:
         # finally pass the changed items grouped by their media import to Kodi
         for (mediaImport, changedItems) in changedItemsMap.items():
             if xbmcmediaimport.changeImportedItems(mediaImport, changedItems):
-                log('changed {} imported items for media import {}'.format(len(changedItems), mediaImport2str(mediaImport)))
+                log(
+                    f"changed {len(changedItems)} imported items for media import {mediaImport2str(mediaImport)}",
+                    xbmc.LOGINFO
+                )
             else:
-                log('failed to change {} imported items for media import {}'.format(len(changedItems), mediaImport2str(mediaImport)), xbmc.LOGWARNING)
+                log(
+                    (
+                        f"failed to change {len(changedItems)} imported items "
+                        f"for media import {mediaImport2str(mediaImport)}"
+                    ),
+                    xbmc.LOGWARNING
+                )
 
-    def _GetItemDetails(self, plexItemId, plexItemClass=None):
-        return Api.getPlexItemAsListItem(self._server.PlexServer(), plexItemId, plexItemClass)
+    def _GetItemDetails(self, plexItemId: int, plexItemClass: plexapi.video.Video = None) -> xbmcgui.ListItem:
+        """Pull details of plex item from the PMS server as a kodi ListItem
 
-    def _FindImportForItem(self, item):
+        :param plexItemId: ID of the item in PMS to get the details of
+        :type plexItemId: int
+        :param plexItemClass: Plex video object media type
+        :type plexItemClass: :class:`plexapi.video.Video`, optional
+        :return: ListItem object populated with the details of the plex item
+        :rtype: :class:`xbmc.ListItem`
+        """
+        return api.Api.getPlexItemAsListItem(self._server.PlexServer(), plexItemId, plexItemClass)
+
+    def _FindImportForItem(self, item: xbmcgui.ListItem) -> xbmcmediaimport.MediaImport:
+        """Find a matching MediaImport in the imports list for the provided ListItem
+
+        :param item: The plex import item in ListItem object to find a matching import for
+        :type item: :class:`xbmcgui.ListItem`
+        :return: The matching MediaImport item if found
+        :rtype: :class:`xbmcmediaimport.MediaImport`
+        """
         videoInfoTag = item.getVideoInfoTag()
         if not videoInfoTag:
             return None
 
         itemMediaType = videoInfoTag.getMediaType()
 
-        matchingImports = [ mediaImport for mediaImport in self._imports if itemMediaType in mediaImport.getMediaTypes() ]
+        matchingImports = [mediaImport for mediaImport in self._imports if itemMediaType in mediaImport.getMediaTypes()]
         if not matchingImports:
             return None
 
         return matchingImports[0]
 
-    def _StartAction(self, mediaProvider):
+    def _StartAction(self, mediaProvider: xbmcmediaimport.MediaProvider) -> bool:
+        """Establish websocket connection to the provided MediaProvder and begin listening
+
+        :param mediaProvider: MediaProvider with websocket to connect to
+        :type mediaProvider: :class:`xbmcmediaimport.MediaProvider`
+        :return: Whether the connection was successful or not
+        :rtype: bool
+        """
         if not mediaProvider:
             raise RuntimeError('invalid mediaProvider')
 
         # if we are already connected check if something important changed in the media provider
         if self._connected:
-            if Api.compareMediaProviders(self._mediaProvider, mediaProvider):
+            if api.Api.compareMediaProviders(self._mediaProvider, mediaProvider):
                 return True
 
         self._StopAction(restart=True)
@@ -347,7 +517,7 @@ class ProviderObserver:
             authenticated = False
 
         if not authenticated:
-            log('failed to authenticate with {}'.format(mediaProvider2str(self._mediaProvider)), xbmc.LOGERROR)
+            log(f"failed to authenticate with {mediaProvider2str(self._mediaProvider)}", xbmc.LOGERROR)
             self._Reset()
             return False
 
@@ -358,25 +528,34 @@ class ProviderObserver:
         try:
             self._websocket.connect(url)
         except:
-            log('failed to connect to {} using a websocket'.format(url), xbmc.LOGERROR)
+            log(f"failed to connect to {url} using a websocket", xbmc.LOGERROR)
             self._Reset()
             return False
 
-        log('successfully connected to {} to observe media imports'.format(mediaProvider2str(self._mediaProvider)))
+        log(
+            f"successfully connected to {mediaProvider2str(self._mediaProvider)} to observe media imports",
+            xbmc.LOGINFO
+        )
         self._connected = True
         return True
 
-    def _StopAction(self, restart=False):
+    def _StopAction(self, restart: bool = False):
+        """Close the current websocket connection and reset connection details back to defaults
+
+        :param restart: Whether the connection should be re-started or not
+        :type restart: bool, optional
+        """
         if not self._connected:
             return
 
         if not restart:
-            log('stopped observing media imports from {}'.format(mediaProvider2str(self._mediaProvider)))
+            log(f"stopped observing media imports from {mediaProvider2str(self._mediaProvider)}", xbmc.LOGINFO)
 
         self._websocket.close()
         self._Reset()
 
     def _Reset(self):
+        """Reset connection state variables back to defaults"""
         self._connected = False
         self._server = None
         self._mediaProvider = None

--- a/plex/server.py
+++ b/plex/server.py
@@ -8,13 +8,23 @@
 
 from plexapi.server import PlexServer
 
-from lib.utils import Url
-from plex.constants import \
-    PLEX_PROTOCOL, \
-    SETTINGS_PROVIDER_AUTHENTICATION, SETTINGS_PROVIDER_AUTHENTICATION_OPTION_LOCAL, SETTINGS_PROVIDER_TOKEN
+from plex.constants import (
+    PLEX_PROTOCOL,
+    SETTINGS_PROVIDER_AUTHENTICATION,
+    SETTINGS_PROVIDER_AUTHENTICATION_OPTION_LOCAL,
+    SETTINGS_PROVIDER_TOKEN
+)
+
+import xbmcmediaimport
+
 
 class Server:
-    def __init__(self, provider):
+    """Class to represent a Plex Media Server with helper methods for interacting with the plexapi
+
+    :param provider: MediaProver from Kodi to implement
+    :type provider: :class:`xbmcmediaimport.MediaProvider`
+    """
+    def __init__(self, provider: xbmcmediaimport.MediaProvider):
         if not provider:
             raise ValueError('Invalid provider')
 
@@ -26,12 +36,13 @@ class Server:
             raise ValueError('Invalid provider without settings')
 
         self._localOnly = settings.getInt(SETTINGS_PROVIDER_AUTHENTICATION) == SETTINGS_PROVIDER_AUTHENTICATION_OPTION_LOCAL
-        self._token = None
+        self._token = ""
         if not self._localOnly:
-            self._token =  settings.getString(SETTINGS_PROVIDER_TOKEN)
+            self._token = settings.getString(SETTINGS_PROVIDER_TOKEN)
         self._plex = None
 
     def Authenticate(self):
+        """Create an authenticated session with the Plex server"""
         if not self._plex:
             try:
                 self._plex = PlexServer(baseurl=self._url, token=self._token)
@@ -40,28 +51,50 @@ class Server:
 
         return self._plex is not None
 
-    def Id(self):
+    def Id(self) -> int:
+        """Get the Id of the plex server"""
         return self._id
 
-    def Url(self):
+    def Url(self) -> str:
+        """Get the Url of the plex server"""
         return self._url
 
-    def AccessToken(self):
+    def AccessToken(self) -> str:
+        """Get the AccessToken for the plex server"""
         return self._token
 
-    def PlexServer(self):
+    def PlexServer(self) -> PlexServer:
+        """Get an authenticated plex session object from plexapi
+
+        :return: Authenticated plex session through plexapi PlexServer object
+        :rtype: :class:`PlexServer`
+        """
         self.Authenticate()
         return self._plex
 
     @staticmethod
-    def BuildProviderId(serverId):
+    def BuildProviderId(serverId: int):
+        """Format a ProviderId string using the provided serverId
+
+        :param serverId: ID of the server to format into a PrivderId
+        :type serverId: int
+        :return: ProviderId formatted string
+        :rtype: str
+        """
         if not serverId:
             raise ValueError('Invalid serverId')
 
-        return '{}://{}/'.format(PLEX_PROTOCOL, serverId)
+        return f"{PLEX_PROTOCOL}://{serverId}/"
 
     @staticmethod
-    def BuildIconUrl(baseUrl):
+    def BuildIconUrl(baseUrl: str) -> str:
+        """Format the URL for icons from the provided baseUrl, NOT IMPLEMENTED
+
+        :param baseUrl: URL to use as the base for the icon url
+        :type baseUrl: str
+        :return: Formatted Icon URL string
+        :rtype: str
+        """
         if not baseUrl:
             raise ValueError('Invalid baseUrl')
 


### PR DESCRIPTION
Tested on local kodi install and confirmed that importing, playback, etc. was all good.

### Main Changes
 * Added docstrings to all functions, methods, packages, etc.
 * Added type annotations to all function and method definitions
 * Updated all in-line string formats with f-strings
 * Brought all lines within the 120 PEP8 limit
 * Added xbmc.LOGINFO to all logs where it was omitted for explicitness
 * Replaced all instances of `not <var> in <var>` with `<var> not in <var>`
   * This works as intended, but 'not in' is convention and linter complains
 * Additional imports in most files due to type annotations
 * Renamed 'localise' from utils to 'localize'
 * Replaced all instances of "None" defaults on primitives with their null versions to match typing (IE `my_string = None` with `my_string = ""`; this still evaluates to None in a condition check but keeps the linter happy now that types are annotated)

### MyPlex Link Fix
 * Cause: dialog.ok() for pin feedback had 3 input when function takes 2
 * Added pin as an additional string to the localized str with new-line
   * Doesn't center the pin so it doesn't look amazing, but works

### Localize Changes
 * unicodedata wasn't being imported in utils.py so the normalizeString function was not doing anything
   * This resulted in a mix of bytestring or regular string returning based on the input
 * Added unicodedata import so ensure normalizeString was working, causing everything be encoded
   * This resulted in several other parts of the code failing due to regular string being expected, namely all instances of .format() on the result of localize as bytestrings do not have formatting
     * Added format_input as an optional paramter to localize to have it .format the localization string before passing it to normalizeString to keep the functionality while getting the consistent bytestring response
   * A few other instances in the code that were expecting strings were fixed by adding .decode() to the response in those instances
     * SUBTITLE_UNKNOWN in player.py
     * localizedMediaType in importer.py

### Thoughts I Had Too Late
f-strings and type annotations are python3 exclusive features. I did utils last and didn't think about the python2/python3 mixed usage until then, so I may need to back out all the fstrings and annotations if keeping python2 support is still necessary; let me know.