### PR TITLE
Update local plexapi copy, add use of pagination, add support for delta sync

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -5,6 +5,7 @@
         <import addon="script.module.websocket_client" version="0.57.0"/>
         <import addon="script.module.requests" />
         <import addon="script.module.six" />
+        <import addon="script.module.dateutil" />
         <!-- <import addon="script.module.web-pdb" /> -->
     </requires>
     <extension point="kodi.mediaimporter" discovery="discovery.py" library="importer.py" observer="observer.py">

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#  Copyright (C) 2020 Sascha Montellese <montellese@kodi.tv>
+#
+#  SPDX-License-Identifier: GPL-2.0-or-later
+#  See LICENSES/README.md for more information.
+#
+
+import hashlib
+import json
+from six import ensure_binary
+from typing import List
+
+from plex.constants import (
+    SETTINGS_IMPORT_SYNC_SETTINGS_HASH,
+    SETTINGS_IMPORT_LIBRARY_SECTIONS
+)
+
+import xbmcaddon
+
+
+class SynchronizationSettings:
+    """Class for interacting with the import settings hash for determining settings changes effect synchronization"""
+    @staticmethod
+    def GetHash(importSettings: xbmcaddon.Settings) -> str:
+        """Get current settings hash
+
+        :param importSettings: Kodi import settings object to pull hash from
+        :type importSettings: :class:`xbmcaddmon.Settings`
+        :return: Current settings hash pulled from Kodi
+        :rtype: str
+        """
+        if not importSettings:
+            raise ValueError('invalid importSettings')
+
+        return importSettings.getString(SETTINGS_IMPORT_SYNC_SETTINGS_HASH)
+
+    @staticmethod
+    def SaveHash(importSettings: xbmcaddon.Settings, hashHex: str):
+        """Save a settings hash string into the Kodi settings
+
+        :param importSettings: Kodi settings object to store the hash into
+        :type importSettings: :class:`xbmcaddmon.Settings`
+        :param hashHex: Hex string to store in the Kodi settings
+        :type hashHex: str
+        """
+        if not importSettings:
+            raise ValueError('invalid importSettings')
+        if not hashHex:
+            raise ValueError('invalid hashHex')
+
+        importSettings.setString(SETTINGS_IMPORT_SYNC_SETTINGS_HASH, hashHex)
+        importSettings.save()
+
+    @staticmethod
+    def CalculateHash(importSettings: xbmcaddon.Settings, providerSettings: xbmcaddon.Settings, save: bool = True):
+        """Generate the settings hash from the current settings in provided importSettings
+
+        :param importSettings: Kodi settings object to pull the current import settings from
+        :type importSettings: :class:`xbmcaddmon.Settings`
+        :param providerSettings: Kodi settings object to pull the current provider settings from
+        :type providerSettings: :class:`xbmcaddmon.Settings`
+        :param save: Whether the generated hash should be stored into the settings object or not
+        :type save: bool
+        """
+        if not importSettings:
+            raise ValueError('invalid importSettings')
+
+        # import specific settings
+        librarySections = importSettings.getStringList(SETTINGS_IMPORT_LIBRARY_SECTIONS)
+
+        hashObject = {
+            # import specific settings
+            SETTINGS_IMPORT_LIBRARY_SECTIONS: librarySections,
+        }
+
+        # serialize the object into JSON
+        hashString = json.dumps(hashObject)
+
+        # hash the JSON serialized object
+        hash = hashlib.sha1(ensure_binary(hashString))
+        hashHex = hash.hexdigest()
+
+        if save:
+            SynchronizationSettings.SaveHash(importSettings, hashHex)
+
+        return hashHex
+
+    @staticmethod
+    def HaveChanged(importSettings: xbmcaddon.Settings, providerSettings: xbmcaddon.Settings, save: bool = True):
+        """Check if the setting have changed by generating a new hash and comparing it to the stored one
+
+        :param importSettings: Kodi settings object to pull the current import settings from
+        :type importSettings: :class:`xbmcaddmon.Settings`
+        :param providerSettings: Kodi settings object to pull the current provider settings from
+        :type providerSettings: :class:`xbmcaddmon.Settings`
+        :param save: Whether the new hash should be stored into the settings object if it has changed
+        :type save: bool
+        """
+        if not importSettings:
+            raise ValueError('invalid importSettings')
+
+        oldHash = SynchronizationSettings.GetHash(importSettings)
+        newHash = SynchronizationSettings.CalculateHash(importSettings, providerSettings, save=False)
+
+        if oldHash == newHash:
+            return False
+
+        if save:
+            SynchronizationSettings.SaveHash(importSettings, newHash)
+
+        return True
+    
+    @staticmethod
+    def ResetHash(importSettings: xbmcaddon.Settings, save: bool = True):
+        """Reset the settings hash to empty to force a full sync on next run
+        :param importSettings: Kodi settings object to store the empty settings hash into
+        :type importSettings: :class:`xbmcaddmon.Settings`
+        :param save: Whether the new hash should be stored into the settings object if it has changed
+        :type save: bool
+        """
+        if not importSettings:
+            raise ValueError('invalid importSettings')
+
+        importSettings.setString(SETTINGS_IMPORT_SYNC_SETTINGS_HASH, '')
+        if save:
+            importSettings.save()

--- a/plex/constants.py
+++ b/plex/constants.py
@@ -96,6 +96,8 @@ SETTINGS_PROVIDER_PLAYBACK_ENABLE_EXTERNAL_SUBTITLES = 'plex.enableexternalsubti
 
 # media import setting identifiers and values
 SETTINGS_IMPORT_LIBRARY_SECTIONS = 'plex.librarysections'
+SETTINGS_IMPORT_SYNC_SETTINGS_HASH = 'plex.syncsettingshash'
+SETTINGS_IMPORT_FORCE_SYNC = 'plex.forcesync'
 
 # player states below
 PLEX_PLAYER_PLAYING = 'playing'

--- a/plex/provider_observer.py
+++ b/plex/provider_observer.py
@@ -377,8 +377,10 @@ class ProviderObserver:
         changedItems = []
         for (changesetType, plexItemId, plexItemClass) in changedPlexItems:
             item = None
-            if changesetType in \
-               (xbmcmediaimport.MediaImportChangesetTypeAdded, xbmcmediaimport.MediaImportChangesetTypeChanged):
+            if changesetType in (
+                    xbmcmediaimport.MediaImportChangesetTypeAdded,
+                    xbmcmediaimport.MediaImportChangesetTypeChanged
+            ):
                 # get all details for the added / changed item
                 item = self._GetItemDetails(plexItemId, plexItemClass)
                 if not item:
@@ -475,8 +477,7 @@ class ProviderObserver:
 
         itemMediaType = videoInfoTag.getMediaType()
 
-        matchingImports = \
-            [mediaImport for mediaImport in self._imports if itemMediaType in mediaImport.getMediaTypes()]
+        matchingImports = [mediaImport for mediaImport in self._imports if itemMediaType in mediaImport.getMediaTypes()]
         if not matchingImports:
             return None
 

--- a/plex/server.py
+++ b/plex/server.py
@@ -35,8 +35,9 @@ class Server:
         if not settings:
             raise ValueError('Invalid provider without settings')
 
-        self._localOnly = \
+        self._localOnly = bool(
             settings.getInt(SETTINGS_PROVIDER_AUTHENTICATION) == SETTINGS_PROVIDER_AUTHENTICATION_OPTION_LOCAL
+        )
         self._token = ""
         if not self._localOnly:
             self._token = settings.getString(SETTINGS_PROVIDER_TOKEN)

--- a/plexapi/__init__.py
+++ b/plexapi/__init__.py
@@ -14,7 +14,7 @@ CONFIG = PlexConfig(CONFIG_PATH)
 
 # PlexAPI Settings
 PROJECT = 'PlexAPI'
-VERSION = '3.3.0'
+VERSION = '3.5.0'
 TIMEOUT = CONFIG.get('plexapi.timeout', 30, int)
 X_PLEX_CONTAINER_SIZE = CONFIG.get('plexapi.container_size', 100, int)
 X_PLEX_ENABLE_FAST_CONNECT = CONFIG.get('plexapi.enable_fast_connect', False, bool)

--- a/plexapi/alert.py
+++ b/plexapi/alert.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import threading
-import websocket
+
 from plexapi import log
 
 
@@ -40,6 +40,11 @@ class AlertListener(threading.Thread):
         self._ws = None
 
     def run(self):
+        try:
+            import websocket
+        except ImportError:
+            log.warning("Can't use the AlertListener without websocket")
+            return
         # create the websocket connection
         url = self._server.url(self.key, includeToken=True).replace('http', 'ws')
         log.info('Starting AlertListener: %s', url)
@@ -57,10 +62,10 @@ class AlertListener(threading.Thread):
 
     def _onMessage(self, *args):
         """ Called when websocket message is received.
-            In earlier releases, websocket-client returned a tuple of two parameters: a websocket.app.WebSocketApp object
-            and the message as a STR. Current releases appear to only return the message.
+            In earlier releases, websocket-client returned a tuple of two parameters: a websocket.app.WebSocketApp
+            object and the message as a STR. Current releases appear to only return the message.
             We are assuming the last argument in the tuple is the message.
-            This is to support compatibility with current and previous releases of websocket-client. 
+            This is to support compatibility with current and previous releases of websocket-client.
         """
         message = args[-1]
         try:
@@ -73,10 +78,10 @@ class AlertListener(threading.Thread):
 
     def _onError(self, *args):  # pragma: no cover
         """ Called when websocket error is received.
-            In earlier releases, websocket-client returned a tuple of two parameters: a websocket.app.WebSocketApp object
-            and the error. Current releases appear to only return the error.
-            We are assuming the last argument in the tuple is the message. 
-            This is to support compatibility with current and previous releases of websocket-client. 
+            In earlier releases, websocket-client returned a tuple of two parameters: a websocket.app.WebSocketApp
+            object and the error. Current releases appear to only return the error.
+            We are assuming the last argument in the tuple is the message.
+            This is to support compatibility with current and previous releases of websocket-client.
         """
         err = args[-1]
         log.error('AlertListener Error: %s' % err)

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -132,6 +132,8 @@ class PlexObject(object):
                     * __regex: Value matches the specified regular expression.
                     * __startswith: Value starts with specified arg.
         """
+        if ekey is None:
+            raise BadRequest('ekey was not provided')
         if isinstance(ekey, int):
             ekey = '/library/metadata/%s' % ekey
         for elem in self._server.query(ekey):
@@ -140,13 +142,27 @@ class PlexObject(object):
         clsname = cls.__name__ if cls else 'None'
         raise NotFound('Unable to find elem: cls=%s, attrs=%s' % (clsname, kwargs))
 
-    def fetchItems(self, ekey, cls=None, **kwargs):
+    def fetchItems(self, ekey, cls=None, container_start=None, container_size=None, **kwargs):
         """ Load the specified key to find and build all items with the specified tag
             and attrs. See :func:`~plexapi.base.PlexObject.fetchItem` for more details
             on how this is used.
+
+            Parameters:
+                container_start (None, int): offset to get a subset of the data
+                container_size (None, int): How many items in data
+
         """
-        data = self._server.query(ekey)
+        url_kw = {}
+        if container_start is not None:
+            url_kw["X-Plex-Container-Start"] = container_start
+        if container_size is not None:
+            url_kw["X-Plex-Container-Size"] = container_size
+
+        if ekey is None:
+            raise BadRequest('ekey was not provided')
+        data = self._server.query(ekey, params=url_kw)
         items = self.findItems(data, cls, ekey, **kwargs)
+
         librarySectionID = data.attrib.get('librarySectionID')
         if librarySectionID:
             for item in items:
@@ -429,6 +445,132 @@ class PlexPartialObject(PlexObject):
         """
         return self._server.history(maxresults=maxresults, mindate=mindate, ratingKey=self.ratingKey)
 
+    def posters(self):
+        """ Returns list of available poster objects. :class:`~plexapi.media.Poster`. """
+
+        return self.fetchItems('%s/posters' % self.key)
+
+    def uploadPoster(self, url=None, filepath=None):
+        """ Upload poster from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        if url:
+            key = '%s/posters?url=%s' % (self.key, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '%s/posters?' % self.key
+            data = open(filepath, 'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+    def setPoster(self, poster):
+        """ Set . :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
+        poster.select()
+
+    def arts(self):
+        """ Returns list of available art objects. :class:`~plexapi.media.Poster`. """
+
+        return self.fetchItems('%s/arts' % self.key)
+
+    def uploadArt(self, url=None, filepath=None):
+        """ Upload art from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        if url:
+            key = '/library/metadata/%s/arts?url=%s' % (self.ratingKey, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '/library/metadata/%s/arts?' % self.ratingKey
+            data = open(filepath, 'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+    def setArt(self, art):
+        """ Set :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
+        art.select()
+
+    def unmatch(self):
+        """ Unmatches metadata match from object. """
+        key = '/library/metadata/%s/unmatch' % self.ratingKey
+        self._server.query(key, method=self._server._session.put)
+
+    def matches(self, agent=None, title=None, year=None, language=None):
+        """ Return list of (:class:`~plexapi.media.SearchResult`) metadata matches.
+
+             Parameters:
+                agent (str): Agent name to be used (imdb, thetvdb, themoviedb, etc.)
+                title (str): Title of item to search for
+                year (str): Year of item to search in
+                language (str) : Language of item to search in
+
+            Examples:
+                1. video.matches()
+                2. video.matches(title="something", year=2020)
+                3. video.matches(title="something")
+                4. video.matches(year=2020)
+                5. video.matches(title="something", year="")
+                6. video.matches(title="", year=2020)
+                7. video.matches(title="", year="")
+
+                1. The default behaviour in Plex Web = no params in plexapi
+                2. Both title and year specified by user
+                3. Year automatically filled in
+                4. Title automatically filled in
+                5. Explicitly searches for title with blank year
+                6. Explicitly searches for blank title with year
+                7. I don't know what the user is thinking... return the same result as 1
+
+                For 2 to 7, the agent and language is automatically filled in
+        """
+        key = '/library/metadata/%s/matches' % self.ratingKey
+        params = {'manual': 1}
+
+        if agent and not any([title, year, language]):
+            params['language'] = self.section().language
+            params['agent'] = utils.getAgentIdentifier(self.section(), agent)
+        else:
+            if any(x is not None for x in [agent, title, year, language]):
+                if title is None:
+                    params['title'] = self.title
+                else:
+                    params['title'] = title
+
+                if year is None:
+                    params['year'] = self.year
+                else:
+                    params['year'] = year
+
+                params['language'] = language or self.section().language
+
+                if agent is None:
+                    params['agent'] = self.section().agent
+                else:
+                    params['agent'] = utils.getAgentIdentifier(self.section(), agent)
+
+        key = key + '?' + urlencode(params)
+        data = self._server.query(key, method=self._server._session.get)
+        return self.findItems(data, initpath=key)
+
+    def fixMatch(self, searchResult=None, auto=False, agent=None):
+        """ Use match result to update show metadata.
+
+            Parameters:
+                auto (bool): True uses first match from matches
+                    False allows user to provide the match
+                searchResult (:class:`~plexapi.media.SearchResult`): Search result from
+                    ~plexapi.base.matches()
+                agent (str): Agent name to be used (imdb, thetvdb, themoviedb, etc.)
+        """
+        key = '/library/metadata/%s/match' % self.ratingKey
+        if auto:
+            autoMatch = self.matches(agent=agent)
+            if autoMatch:
+                searchResult = autoMatch[0]
+            else:
+                raise NotFound('No matches found using this agent: (%s:%s)' % (agent, autoMatch))
+        elif not searchResult:
+            raise NotFound('fixMatch() requires either auto=True or '
+                           'searchResult=:class:`~plexapi.media.SearchResult`.')
+
+        params = {'guid': searchResult.guid,
+                  'name': searchResult.name}
+
+        data = key + '?' + urlencode(params)
+        self._server.query(data, method=self._server._session.put)
 
     # The photo tag cant be built atm. TODO
     # def arts(self):
@@ -518,6 +660,14 @@ class Playable(object):
         key = '%s/split' % self.key
         return self._server.query(key, method=self._server._session.put)
 
+    def merge(self, ratingKeys):
+        """Merge duplicate items."""
+        if not isinstance(ratingKeys, list):
+            ratingKeys = str(ratingKeys).split(",")
+
+        key = '%s/merge?ids=%s' % (self.key, ','.join(ratingKeys))
+        return self._server.query(key, method=self._server._session.put)
+
     def unmatch(self):
         """Unmatch a media file."""
         key = '%s/unmatch' % self.key
@@ -582,7 +732,7 @@ class Playable(object):
                                                                                               time, state)
         self._server.query(key)
         self.reload()
-        
+
     def updateTimeline(self, time, state='stopped', duration=None):
         """ Set the timeline progress for this video.
 

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 import time
-import requests
 
-from requests.status_codes import _codes as codes
-from plexapi import BASE_HEADERS, CONFIG, TIMEOUT
-from plexapi import log, logfilter, utils
+import requests
+from plexapi import BASE_HEADERS, CONFIG, TIMEOUT, log, logfilter, utils
 from plexapi.base import PlexObject
 from plexapi.compat import ElementTree
-from plexapi.exceptions import BadRequest, Unsupported
+from plexapi.exceptions import BadRequest, NotFound, Unauthorized, Unsupported
 from plexapi.playqueue import PlayQueue
-
+from requests.status_codes import _codes as codes
 
 DEFAULT_MTYPE = 'video'
 
@@ -159,11 +157,16 @@ class PlexClient(PlexObject):
         log.debug('%s %s', method.__name__.upper(), url)
         headers = self._headers(**headers or {})
         response = method(url, headers=headers, timeout=timeout, **kwargs)
-        if response.status_code not in (200, 201):
+        if response.status_code not in (200, 201, 204):
             codename = codes.get(response.status_code)[0]
             errtext = response.text.replace('\n', ' ')
-            log.warning('BadRequest (%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
-            raise BadRequest('(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext))
+            message = '(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext)
+            if response.status_code == 401:
+                raise Unauthorized(message)
+            elif response.status_code == 404:
+                raise NotFound(message)
+            else:
+                raise BadRequest(message)
         data = response.text.encode('utf8')
         return ElementTree.fromstring(data) if data.strip() else None
 
@@ -204,10 +207,13 @@ class PlexClient(PlexObject):
             return query(key, headers=headers)
         except ElementTree.ParseError:
             # Workaround for players which don't return valid XML on successful commands
-            #   - Plexamp: `b'OK'`
+            #   - Plexamp, Plex for Android: `b'OK'`
+            #   - Plex for Samsung: `b'<?xml version="1.0"?><Response code="200" status="OK">'`
             if self.product in (
                 'Plexamp',
                 'Plex for Android (TV)',
+                'Plex for Android (Mobile)',
+                'Plex for Samsung',
             ):
                 return
             raise
@@ -469,10 +475,15 @@ class PlexClient(PlexObject):
 
         if hasattr(media, "playlistType"):
             mediatype = media.playlistType
-        elif media.listType == "audio":
-            mediatype = "music"
         else:
-            mediatype = "video"
+            if isinstance(media, PlayQueue):
+                mediatype = media.items[0].listType
+            else:
+                mediatype = media.listType
+
+        # mediatype must be in ["video", "music", "photo"]
+        if mediatype == "audio":
+            mediatype = "music"
 
         if self.product != 'OpenPHT':
             try:
@@ -537,9 +548,9 @@ class PlexClient(PlexObject):
 
     # -------------------
     # Timeline Commands
-    def timeline(self):
+    def timeline(self, wait=1):
         """ Poll the current timeline and return the XML response. """
-        return self.sendCommand('timeline/poll', wait=1)
+        return self.sendCommand('timeline/poll', wait=wait)
 
     def isPlayingMedia(self, includePaused=False):
         """ Returns True if any media is currently playing.
@@ -548,7 +559,7 @@ class PlexClient(PlexObject):
                 includePaused (bool): Set True to treat currently paused items
                     as playing (optional; default True).
         """
-        for mediatype in self.timeline():
+        for mediatype in self.timeline(wait=0):
             if mediatype.get('state') == 'playing':
                 return True
             if includePaused and mediatype.get('state') == 'paused':

--- a/plexapi/compat.py
+++ b/plexapi/compat.py
@@ -25,9 +25,9 @@ except ImportError:
     from urllib import quote
 
 try:
-    from urllib.parse import quote_plus
+    from urllib.parse import quote_plus, quote
 except ImportError:
-    from urllib import quote_plus
+    from urllib import quote_plus, quote
 
 try:
     from urllib.parse import unquote
@@ -39,20 +39,18 @@ try:
 except ImportError:
     from ConfigParser import ConfigParser
 
-# Montellese: cElementTree is not reliable in Kodi
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    from xml.etree import ElementTree
+# mediaimport.plex patch: cElementTree is not reliable in Kodi
 # try:
 #     from xml.etree import cElementTree as ElementTree
 # except ImportError:
 #     from xml.etree import ElementTree
 from xml.etree import ElementTree
 
-# Montellese: not needed
-# try:
-#     from unittest.mock import patch, MagicMock
-# except ImportError:
-#     from mock import patch, MagicMock
-
-# Montellese: Kodi specific problem, see https://forum.kodi.tv/showthread.php?tid=112916&pid=2914578#pid2914578
+# mediaimprot.plex patch: Kodi specific problem, see https://forum.kodi.tv/showthread.php?tid=112916&pid=2914578#pid2914578
 import datetime
 
 #fix for datatetime.strptime returns None

--- a/plexapi/exceptions.py
+++ b/plexapi/exceptions.py
@@ -26,6 +26,6 @@ class Unsupported(PlexApiException):
     pass
 
 
-class Unauthorized(PlexApiException):
-    """ Invalid username or password. """
+class Unauthorized(BadRequest):
+    """ Invalid username/password or token. """
     pass

--- a/plexapi/gdm.py
+++ b/plexapi/gdm.py
@@ -1,0 +1,148 @@
+"""
+Support for discovery using GDM (Good Day Mate), multicast protocol by Plex.
+
+# Licensed Apache 2.0
+# From https://github.com/home-assistant/netdisco/netdisco/gdm.py
+
+Inspired by:
+  hippojay's plexGDM: https://github.com/hippojay/script.plexbmc.helper/resources/lib/plexgdm.py
+  iBaa's PlexConnect: https://github.com/iBaa/PlexConnect/PlexAPI.py
+"""
+import socket
+import struct
+
+
+class GDM:
+    """Base class to discover GDM services."""
+
+    def __init__(self):
+        self.entries = []
+        self.last_scan = None
+
+    def scan(self, scan_for_clients=False):
+        """Scan the network."""
+        self.update(scan_for_clients)
+
+    def all(self):
+        """Return all found entries.
+
+        Will scan for entries if not scanned recently.
+        """
+        self.scan()
+        return list(self.entries)
+
+    def find_by_content_type(self, value):
+        """Return a list of entries that match the content_type."""
+        self.scan()
+        return [entry for entry in self.entries
+                if value in entry['data']['Content_Type']]
+
+    def find_by_data(self, values):
+        """Return a list of entries that match the search parameters."""
+        self.scan()
+        return [entry for entry in self.entries
+                if all(item in entry['data'].items()
+                       for item in values.items())]
+
+    def update(self, scan_for_clients):
+        """Scan for new GDM services.
+
+        Examples of the dict list assigned to self.entries by this function:
+
+            Server:
+
+                [{'data': {
+                     'Content-Type': 'plex/media-server',
+                     'Host': '53f4b5b6023d41182fe88a99b0e714ba.plex.direct',
+                     'Name': 'myfirstplexserver',
+                     'Port': '32400',
+                     'Resource-Identifier': '646ab0aa8a01c543e94ba975f6fd6efadc36b7',
+                     'Updated-At': '1585769946',
+                     'Version': '1.18.8.2527-740d4c206',
+                },
+                 'from': ('10.10.10.100', 32414)}]
+
+            Clients:
+
+                [{'data': {'Content-Type': 'plex/media-player',
+                     'Device-Class': 'stb',
+                     'Name': 'plexamp',
+                     'Port': '36000',
+                     'Product': 'Plexamp',
+                     'Protocol': 'plex',
+                     'Protocol-Capabilities': 'timeline,playback,playqueues,playqueues-creation',
+                     'Protocol-Version': '1',
+                     'Resource-Identifier': 'b6e57a3f-e0f8-494f-8884-f4b58501467e',
+                     'Version': '1.1.0',
+                },
+                 'from': ('10.10.10.101', 32412)}]
+        """
+
+        gdm_msg = 'M-SEARCH * HTTP/1.0'.encode('ascii')
+        gdm_timeout = 1
+
+        self.entries = []
+        known_responses = []
+
+        # setup socket for discovery -> multicast message
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.settimeout(gdm_timeout)
+
+        # Set the time-to-live for messages for local network
+        sock.setsockopt(socket.IPPROTO_IP,
+                        socket.IP_MULTICAST_TTL,
+                        struct.pack("B", gdm_timeout))
+
+        if scan_for_clients:
+            # setup socket for broadcast to Plex clients
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            gdm_ip = '255.255.255.255'
+            gdm_port = 32412
+        else:
+            # setup socket for multicast to Plex server(s)
+            gdm_ip = '239.0.0.250'
+            gdm_port = 32414
+
+        try:
+            # Send data to the multicast group
+            sock.sendto(gdm_msg, (gdm_ip, gdm_port))
+
+            # Look for responses from all recipients
+            while True:
+                try:
+                    bdata, host = sock.recvfrom(1024)
+                    data = bdata.decode('utf-8')
+                    if '200 OK' in data.splitlines()[0]:
+                        ddata = {k: v.strip() for (k, v) in (
+                            line.split(':') for line in
+                            data.splitlines() if ':' in line)}
+                        identifier = ddata.get('Resource-Identifier')
+                        if identifier and identifier in known_responses:
+                            continue
+                        known_responses.append(identifier)
+                        self.entries.append({'data': ddata,
+                                             'from': host})
+                except socket.timeout:
+                    break
+        finally:
+            sock.close()
+
+
+def main():
+    """Test GDM discovery."""
+    from pprint import pprint
+
+    gdm = GDM()
+
+    pprint("Scanning GDM for servers...")
+    gdm.scan()
+    pprint(gdm.entries)
+
+    pprint("Scanning GDM for clients...")
+    gdm.scan(scan_for_clients=True)
+    pprint(gdm.entries)
+
+
+if __name__ == "__main__":
+    main()

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from plexapi import X_PLEX_CONTAINER_SIZE, log, utils
 from plexapi.base import PlexObject
-from plexapi.compat import unquote, urlencode, quote_plus
-from plexapi.media import MediaTag
+from plexapi.compat import quote_plus, unquote, urlencode
 from plexapi.exceptions import BadRequest, NotFound
+from plexapi.media import MediaTag
+from plexapi.settings import Setting
 
 
 class Library(PlexObject):
@@ -331,6 +332,8 @@ class LibrarySection(PlexObject):
             type (str): Type of content section represents (movie, artist, photo, show).
             updatedAt (datetime): Datetime this library section was last updated.
             uuid (str): Unique id for this section (32258d7c-3e6c-4ac5-98ad-bad7a3b78c63)
+            totalSize (int): Total number of item in the library
+
     """
     ALLOWED_FILTERS = ()
     ALLOWED_SORT = ()
@@ -354,6 +357,51 @@ class LibrarySection(PlexObject):
         self.type = data.attrib.get('type')
         self.updatedAt = utils.toDatetime(data.attrib.get('updatedAt'))
         self.uuid = data.attrib.get('uuid')
+        # Private attrs as we dont want a reload.
+        self._total_size = None
+
+    def fetchItems(self, ekey, cls=None, container_start=None, container_size=None, **kwargs):
+        """ Load the specified key to find and build all items with the specified tag
+            and attrs. See :func:`~plexapi.base.PlexObject.fetchItem` for more details
+            on how this is used.
+
+            Parameters:
+                container_start (None, int): offset to get a subset of the data
+                container_size (None, int): How many items in data
+
+        """
+        url_kw = {}
+        if container_start is not None:
+            url_kw["X-Plex-Container-Start"] = container_start
+        if container_size is not None:
+            url_kw["X-Plex-Container-Size"] = container_size
+
+        if ekey is None:
+            raise BadRequest('ekey was not provided')
+        data = self._server.query(ekey, params=url_kw)
+
+        if '/all' in ekey:
+            # totalSize is only included in the xml response
+            # if container size is used.
+            total_size = data.attrib.get("totalSize") or data.attrib.get("size")
+            self._total_size = utils.cast(int, total_size)
+
+        items = self.findItems(data, cls, ekey, **kwargs)
+
+        librarySectionID = data.attrib.get('librarySectionID')
+        if librarySectionID:
+            for item in items:
+                item.librarySectionID = librarySectionID
+        return items
+
+    @property
+    def totalSize(self):
+        if self._total_size is None:
+            part = '/library/sections/%s/all?X-Plex-Container-Start=0&X-Plex-Container-Size=1' % self.key
+            data = self._server.query(part)
+            self._total_size = int(data.attrib.get("totalSize"))
+
+        return self._total_size
 
     def delete(self):
         """ Delete a library section. """
@@ -365,13 +413,18 @@ class LibrarySection(PlexObject):
             log.error(msg)
             raise
 
-    def edit(self, **kwargs):
+    def reload(self, key=None):
+        return self._server.library.section(self.title)
+
+    def edit(self, agent=None, **kwargs):
         """ Edit a library (Note: agent is required). See :class:`~plexapi.library.Library` for example usage.
 
             Parameters:
                 kwargs (dict): Dict of settings to edit.
         """
-        part = '/library/sections/%s?%s' % (self.key, urlencode(kwargs))
+        if not agent:
+            agent = self.agent
+        part = '/library/sections/%s?agent=%s&%s' % (self.key, agent, urlencode(kwargs))
         self._server.query(part, method=self._server._session.put)
 
         # Reload this way since the self.key dont have a full path, but is simply a id.
@@ -400,6 +453,17 @@ class LibrarySection(PlexObject):
 
         key = '/library/sections/%s/all%s' % (self.key, sortStr)
         return self.fetchItems(key, **kwargs)
+
+    def agents(self):
+        """ Returns a list of available `:class:`~plexapi.media.Agent` for this library section.
+        """
+        return self._server.agents(utils.searchType(self.type))
+
+    def settings(self):
+        """ Returns a list of all library settings. """
+        key = '/library/sections/%s/prefs' % self.key
+        data = self._server.query(key)
+        return self.findItems(data, cls=Setting)
 
     def onDeck(self):
         """ Returns a list of media items on deck from this library section. """
@@ -475,9 +539,10 @@ class LibrarySection(PlexObject):
         key = '/library/sections/%s/%s%s' % (self.key, category, utils.joinArgs(args))
         return self.fetchItems(key, cls=FilterChoice)
 
-    def search(self, title=None, sort=None, maxresults=999999, libtype=None, **kwargs):
-        """ Search the library. If there are many results, they will be fetched from the server
-            in batches of X_PLEX_CONTAINER_SIZE amounts. If you're only looking for the first <num>
+    # mediaimport.plex patch: Updated docstring description of kwargs to include ( > < ) filter options
+    def search(self, title=None, sort=None, maxresults=None,
+               libtype=None, container_start=0, container_size=X_PLEX_CONTAINER_SIZE, **kwargs):
+        """ Search the library. The http requests will be batched in container_size. If you're only looking for the first <num>
             results, it would be wise to set the maxresults option to that amount so this functions
             doesn't iterate over all results on the server.
 
@@ -488,9 +553,11 @@ class LibrarySection(PlexObject):
                 maxresults (int): Only return the specified number of results (optional).
                 libtype (str): Filter results to a spcifiec libtype (movie, show, episode, artist,
                     album, track; optional).
+                container_start (int): default 0
+                container_size (int): default X_PLEX_CONTAINER_SIZE in your config file.
                 **kwargs (dict): Any of the available filters for the current library section. Partial string
-                        matches allowed. Multiple matches OR together. Negative filtering also possible, just add an
-                        exclamation mark to the end of filter name, e.g. `resolution!=1x1`.
+                        matches allowed. Multiple matches OR together. Negative  and range filtering also possible,
+                        just add a symbol to the end of filter name, e.g. `resolution! = 1x1` or `lastViewedAt> = 0`
 
                         * unwatched: Display or hide unwatched content (True, False). [all]
                         * duplicate: Display or hide duplicate items (True, False). [movie]
@@ -519,20 +586,44 @@ class LibrarySection(PlexObject):
             args['sort'] = self._cleanSearchSort(sort)
         if libtype is not None:
             args['type'] = utils.searchType(libtype)
-        # iterate over the results
-        results, subresults = [], '_init'
-        args['X-Plex-Container-Start'] = 0
-        args['X-Plex-Container-Size'] = min(X_PLEX_CONTAINER_SIZE, maxresults)
-        while subresults and maxresults > len(results):
+
+        results = []
+        subresults = []
+        offset = container_start
+
+        if maxresults is not None:
+            container_size = min(container_size, maxresults)
+        while True:
             key = '/library/sections/%s/all%s' % (self.key, utils.joinArgs(args))
-            subresults = self.fetchItems(key)
-            results += subresults[:maxresults - len(results)]
-            args['X-Plex-Container-Start'] += args['X-Plex-Container-Size']
+
+            subresults = self.fetchItems(key, container_start=container_start,
+                                         container_size=container_size)
+            if not len(subresults):
+                if offset > self.totalSize:
+                    log.info("container_start is higher then the number of items in the library")
+                break
+
+            results.extend(subresults)
+
+            # self.totalSize is not used as a condition in the while loop as
+            # this require a additional http request.
+            # self.totalSize is updated from .fetchItems
+            wanted_number_of_items = self.totalSize - offset
+            if maxresults is not None:
+                wanted_number_of_items = min(maxresults, wanted_number_of_items)
+                container_size = min(container_size, maxresults - len(results))
+
+            if wanted_number_of_items <= len(results):
+                break
+
+            container_start += container_size
+
         return results
 
     def _cleanSearchFilter(self, category, value, libtype=None):
         # check a few things before we begin
-        if category.endswith('!'):
+        # mediaimport.plex: Patch to include > < operator options
+        if category.endswith('!') or category.endswith('>') or category.endswith('<'):
             if category[:-1] not in self.ALLOWED_FILTERS:
                 raise BadRequest('Unknown filter category: %s' % category[:-1])
         elif category not in self.ALLOWED_FILTERS:
@@ -554,7 +645,7 @@ class LibrarySection(PlexObject):
             matches = [k for t, k in lookup.items() if item in t]
             if matches: map(result.add, matches); continue
             # nothing matched; use raw item value
-            log.warning('Filter value not listed, using raw item value: %s' % item)
+            log.debug('Filter value not listed, using raw item value: %s' % item)
             result.add(item)
         return ','.join(result)
 
@@ -666,12 +757,13 @@ class MovieSection(LibrarySection):
             TAG (str): 'Directory'
             TYPE (str): 'movie'
     """
+    # mediaimport.plex patch: Added updatedAt filter and sort option
     ALLOWED_FILTERS = ('unwatched', 'duplicate', 'year', 'decade', 'genre', 'contentRating',
                        'collection', 'director', 'actor', 'country', 'studio', 'resolution',
                        'guid', 'label', 'writer', 'producer', 'subtitleLanguage', 'audioLanguage',
-                       'lastViewedAt', 'viewCount', 'addedAt')
+                       'lastViewedAt', 'viewCount', 'addedAt', 'updatedAt')
     ALLOWED_SORT = ('addedAt', 'originallyAvailableAt', 'lastViewedAt', 'titleSort', 'rating',
-                    'mediaHeight', 'duration')
+                    'mediaHeight', 'duration', 'updatedAt')
     TAG = 'Directory'
     TYPE = 'movie'
     METADATA_TYPE = 'movie'
@@ -728,14 +820,15 @@ class ShowSection(LibrarySection):
             TAG (str): 'Directory'
             TYPE (str): 'show'
     """
+    # mediaimport.plex patch: Add top-level lastViewedAt and updatedAt options for both filter and sort
     ALLOWED_FILTERS = ('unwatched', 'year', 'genre', 'contentRating', 'network', 'collection',
-                       'guid', 'duplicate', 'label', 'show.title', 'show.year', 'show.userRating',
-                       'show.viewCount', 'show.lastViewedAt', 'show.actor', 'show.addedAt', 'episode.title',
-                       'episode.originallyAvailableAt', 'episode.resolution', 'episode.subtitleLanguage',
-                       'episode.unwatched', 'episode.addedAt', 'episode.userRating', 'episode.viewCount',
-                       'episode.lastViewedAt')
+                       'guid', 'duplicate', 'label', 'lastViewedAt', 'updatedAt', 'show.title',
+                       'show.year', 'show.userRating', 'show.viewCount', 'show.lastViewedAt', 'show.actor',
+                       'show.addedAt', 'episode.title', 'episode.originallyAvailableAt', 'episode.resolution',
+                       'episode.subtitleLanguage', 'episode.unwatched', 'episode.addedAt', 'episode.userRating',
+                       'episode.viewCount', 'episode.lastViewedAt')
     ALLOWED_SORT = ('addedAt', 'lastViewedAt', 'originallyAvailableAt', 'titleSort',
-                    'rating', 'unwatched')
+                    'rating', 'unwatched', 'updatedAt')
     TAG = 'Directory'
     TYPE = 'show'
     METADATA_TYPE = 'episode'
@@ -987,6 +1080,7 @@ class Hub(PlexObject):
         self.size = utils.cast(int, data.attrib.get('size'))
         self.title = data.attrib.get('title')
         self.type = data.attrib.get('type')
+        self.key = data.attrib.get('key')
         self.items = self.findItems(data)
 
     def __len__(self):
@@ -998,9 +1092,11 @@ class Collections(PlexObject):
 
     TAG = 'Directory'
     TYPE = 'collection'
+    _include = "?includeExternalMedia=1&includePreferences=1"
 
     def _loadData(self, data):
         self.ratingKey = utils.cast(int, data.attrib.get('ratingKey'))
+        self._details_key = "/library/metadata/%s%s" % (self.ratingKey, self._include)
         self.key = data.attrib.get('key')
         self.type = data.attrib.get('type')
         self.title = data.attrib.get('title')
@@ -1069,6 +1165,44 @@ class Collections(PlexObject):
             raise BadRequest('Unknown sort dir: %s. Options: %s' % (sort, list(sort_dict)))
         part = '/library/metadata/%s/prefs?collectionSort=%s' % (self.ratingKey, key)
         return self._server.query(part, method=self._server._session.put)
+
+    def posters(self):
+        """ Returns list of available poster objects. :class:`~plexapi.media.Poster`. """
+
+        return self.fetchItems('/library/metadata/%s/posters' % self.ratingKey)
+
+    def uploadPoster(self, url=None, filepath=None):
+        """ Upload poster from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        if url:
+            key = '/library/metadata/%s/posters?url=%s' % (self.ratingKey, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '/library/metadata/%s/posters?' % self.ratingKey
+            data = open(filepath, 'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+    def setPoster(self, poster):
+        """ Set . :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
+        poster.select()
+
+    def arts(self):
+        """ Returns list of available art objects. :class:`~plexapi.media.Poster`. """
+
+        return self.fetchItems('/library/metadata/%s/arts' % self.ratingKey)
+
+    def uploadArt(self, url=None, filepath=None):
+        """ Upload art from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        if url:
+            key = '/library/metadata/%s/arts?url=%s' % (self.ratingKey, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '/library/metadata/%s/arts?' % self.ratingKey
+            data = open(filepath, 'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+    def setArt(self, art):
+        """ Set :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
+        art.select()
 
     # def edit(self, **kwargs):
     #    TODO

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-from plexapi import log, utils
+
+import xml
+
+from plexapi import compat, log, settings, utils
 from plexapi.base import PlexObject
 from plexapi.exceptions import BadRequest
 from plexapi.utils import cast
@@ -143,7 +146,7 @@ class MediaPart(PlexObject):
 
     def setDefaultSubtitleStream(self, stream):
         """ Set the default :class:`~plexapi.media.SubtitleStream` for this MediaPart.
-            
+
             Parameters:
                 stream (:class:`~plexapi.media.SubtitleStream`): SubtitleStream to set as default.
         """
@@ -349,6 +352,118 @@ class TranscodeSession(PlexObject):
         self.width = cast(int, data.attrib.get('width'))
 
 
+@utils.registerPlexObject
+class TranscodeJob(PlexObject):
+    """ Represents an Optimizing job.
+        TrancodeJobs are the process for optimizing conversions.
+        Active or paused optimization items. Usually one item as a time"""
+    TAG = 'TranscodeJob'
+
+    def _loadData(self, data):
+        self._data = data
+        self.generatorID = data.attrib.get('generatorID')
+        self.key = data.attrib.get('key')
+        self.progress = data.attrib.get('progress')
+        self.ratingKey = data.attrib.get('ratingKey')
+        self.size = data.attrib.get('size')
+        self.targetTagID = data.attrib.get('targetTagID')
+        self.thumb = data.attrib.get('thumb')
+        self.title = data.attrib.get('title')
+        self.type = data.attrib.get('type')
+
+
+@utils.registerPlexObject
+class Optimized(PlexObject):
+    """ Represents a Optimized item.
+        Optimized items are optimized and queued conversions items."""
+    TAG = 'Item'
+
+    def _loadData(self, data):
+        self._data = data
+        self.id = data.attrib.get('id')
+        self.composite = data.attrib.get('composite')
+        self.title = data.attrib.get('title')
+        self.type = data.attrib.get('type')
+        self.target = data.attrib.get('target')
+        self.targetTagID = data.attrib.get('targetTagID')
+
+    def remove(self):
+        """ Remove an Optimized item"""
+        key = '%s/%s' % (self._initpath, self.id)
+        self._server.query(key, method=self._server._session.delete)
+
+    def rename(self, title):
+        """ Rename an Optimized item"""
+        key = '%s/%s?Item[title]=%s' % (self._initpath, self.id, title)
+        self._server.query(key, method=self._server._session.put)
+
+    def reprocess(self, ratingKey):
+        """ Reprocess a removed Conversion item that is still a listed Optimize item"""
+        key = '%s/%s/%s/enable' % (self._initpath, self.id, ratingKey)
+        self._server.query(key, method=self._server._session.put)
+
+
+@utils.registerPlexObject
+class Conversion(PlexObject):
+    """ Represents a Conversion item.
+        Conversions are items queued for optimization or being actively optimized."""
+    TAG = 'Video'
+
+    def _loadData(self, data):
+        self._data = data
+        self.addedAt = data.attrib.get('addedAt')
+        self.art = data.attrib.get('art')
+        self.chapterSource = data.attrib.get('chapterSource')
+        self.contentRating = data.attrib.get('contentRating')
+        self.duration = data.attrib.get('duration')
+        self.generatorID = data.attrib.get('generatorID')
+        self.generatorType = data.attrib.get('generatorType')
+        self.guid = data.attrib.get('guid')
+        self.key = data.attrib.get('key')
+        self.lastViewedAt = data.attrib.get('lastViewedAt')
+        self.librarySectionID = data.attrib.get('librarySectionID')
+        self.librarySectionKey = data.attrib.get('librarySectionKey')
+        self.librarySectionTitle = data.attrib.get('librarySectionTitle')
+        self.originallyAvailableAt = data.attrib.get('originallyAvailableAt')
+        self.playQueueItemID = data.attrib.get('playQueueItemID')
+        self.playlistID = data.attrib.get('playlistID')
+        self.primaryExtraKey = data.attrib.get('primaryExtraKey')
+        self.rating = data.attrib.get('rating')
+        self.ratingKey = data.attrib.get('ratingKey')
+        self.studio = data.attrib.get('studio')
+        self.summary = data.attrib.get('summary')
+        self.tagline = data.attrib.get('tagline')
+        self.target = data.attrib.get('target')
+        self.thumb = data.attrib.get('thumb')
+        self.title = data.attrib.get('title')
+        self.type = data.attrib.get('type')
+        self.updatedAt = data.attrib.get('updatedAt')
+        self.userID = data.attrib.get('userID')
+        self.username = data.attrib.get('username')
+        self.viewOffset = data.attrib.get('viewOffset')
+        self.year = data.attrib.get('year')
+
+    def remove(self):
+        """ Remove Conversion from queue """
+        key = '/playlists/%s/items/%s/%s/disable' % (self.playlistID, self.generatorID, self.ratingKey)
+        self._server.query(key, method=self._server._session.put)
+
+    def move(self, after):
+        """ Move Conversion items position in queue
+            after (int): Place item after specified playQueueItemID. '-1' is the active conversion.
+
+                Example:
+                    Move 5th conversion Item to active conversion
+                        conversions[4].move('-1')
+
+                    Move 4th conversion Item to 3rd in conversion queue
+                        conversions[3].move(conversions[1].playQueueItemID)
+        """
+
+        key = '%s/items/%s/move?after=%s' % (self._initpath, self.playQueueItemID, after)
+        self._server.query(key, method=self._server._session.put)
+
+
 class MediaTag(PlexObject):
     """ Base class for media tags used for filtering and searching your library
         items or navigating the metadata of media items in your library. Tags are
@@ -502,6 +617,14 @@ class Poster(PlexObject):
         self.selected = data.attrib.get('selected')
         self.thumb = data.attrib.get('thumb')
 
+    def select(self):
+        key = self._initpath[:-1]
+        data = '%s?url=%s' % (key, compat.quote_plus(self.ratingKey))
+        try:
+            self._server.query(data, method=self._server._session.put)
+        except xml.etree.ElementTree.ParseError:
+            pass
+
 
 @utils.registerPlexObject
 class Producer(MediaTag):
@@ -584,3 +707,74 @@ class Field(PlexObject):
         self._data = data
         self.name = data.attrib.get('name')
         self.locked = cast(bool, data.attrib.get('locked'))
+
+
+@utils.registerPlexObject
+class SearchResult(PlexObject):
+    """ Represents a single SearchResult.
+
+        Attributes:
+            TAG (str): 'SearchResult'
+    """
+    TAG = 'SearchResult'
+
+    def __repr__(self):
+        name = self._clean(self.firstAttr('name'))
+        score = self._clean(self.firstAttr('score'))
+        return '<%s>' % ':'.join([p for p in [self.__class__.__name__, name, score] if p])
+
+    def _loadData(self, data):
+        self._data = data
+        self.guid = data.attrib.get('guid')
+        self.lifespanEnded = data.attrib.get('lifespanEnded')
+        self.name = data.attrib.get('name')
+        self.score = cast(int, data.attrib.get('score'))
+        self.year = data.attrib.get('year')
+
+
+@utils.registerPlexObject
+class Agent(PlexObject):
+    """ Represents a single Agent.
+
+        Attributes:
+            TAG (str): 'Agent'
+    """
+    TAG = 'Agent'
+
+    def __repr__(self):
+        uid = self._clean(self.firstAttr('shortIdentifier'))
+        return '<%s>' % ':'.join([p for p in [self.__class__.__name__, uid] if p])
+
+    def _loadData(self, data):
+        self._data = data
+        self.hasAttribution = data.attrib.get('hasAttribution')
+        self.hasPrefs = data.attrib.get('hasPrefs')
+        self.identifier = data.attrib.get('identifier')
+        self.primary = data.attrib.get('primary')
+        self.shortIdentifier = self.identifier.rsplit('.', 1)[1]
+        if 'mediaType' in self._initpath:
+            self.name = data.attrib.get('name')
+            self.languageCode = []
+            for code in data:
+                self.languageCode += [code.attrib.get('code')]
+        else:
+            self.mediaTypes = [AgentMediaType(server=self._server, data=d) for d in data]
+
+    def _settings(self):
+        key = '/:/plugins/%s/prefs' % self.identifier
+        data = self._server.query(key)
+        return self.findItems(data, cls=settings.Setting)
+
+
+class AgentMediaType(Agent):
+
+    def __repr__(self):
+        uid = self._clean(self.firstAttr('name'))
+        return '<%s>' % ':'.join([p for p in [self.__class__.__name__, uid] if p])
+
+    def _loadData(self, data):
+        self.mediaType = cast(int, data.attrib.get('mediaType'))
+        self.name = data.attrib.get('name')
+        self.languageCode = []
+        for code in data:
+            self.languageCode += [code.attrib.get('code')]

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -268,3 +268,41 @@ class Playlist(PlexPartialObject, Playable):
             raise Unsupported('Unsupported playlist content')
 
         return myplex.sync(sync_item, client=client, clientId=clientId)
+
+    def posters(self):
+        """ Returns list of available poster objects. :class:`~plexapi.media.Poster`. """
+
+        return self.fetchItems('/library/metadata/%s/posters' % self.ratingKey)
+
+    def uploadPoster(self, url=None, filepath=None):
+        """ Upload poster from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        if url:
+            key = '/library/metadata/%s/posters?url=%s' % (self.ratingKey, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '/library/metadata/%s/posters?' % self.ratingKey
+            data = open(filepath, 'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+    def setPoster(self, poster):
+        """ Set . :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
+        poster.select()
+
+    def arts(self):
+        """ Returns list of available art objects. :class:`~plexapi.media.Poster`. """
+
+        return self.fetchItems('/library/metadata/%s/arts' % self.ratingKey)
+
+    def uploadArt(self, url=None, filepath=None):
+        """ Upload art from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        if url:
+            key = '/library/metadata/%s/arts?url=%s' % (self.ratingKey, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '/library/metadata/%s/arts?' % self.ratingKey
+            data = open(filepath, 'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+    def setArt(self, art):
+        """ Set :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
+        art.select()

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -7,12 +7,13 @@ from plexapi.alert import AlertListener
 from plexapi.base import PlexObject
 from plexapi.client import PlexClient
 from plexapi.compat import ElementTree, urlencode
-from plexapi.exceptions import BadRequest, NotFound
+from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 from plexapi.library import Library, Hub
 from plexapi.settings import Settings
 from plexapi.playlist import Playlist
 from plexapi.playqueue import PlayQueue
 from plexapi.utils import cast
+from plexapi.media import Optimized, Conversion
 
 # Need these imports to populate utils.PLEXOBJECTS
 from plexapi import (audio as _audio, video as _video,        # noqa: F401
@@ -183,8 +184,18 @@ class PlexServer(PlexObject):
         data = self.query(Account.key)
         return Account(self, data)
 
+    def agents(self, mediaType=None):
+        """ Returns the `:class:`~plexapi.media.Agent` objects this server has available. """
+        key = '/system/agents'
+        if mediaType:
+            key += '?mediaType=%s' % mediaType
+        return self.fetchItems(key)
+
     def createToken(self, type='delegation', scope='all'):
         """Create a temp access token for the server."""
+        if not self._token:
+            # Handle unclaimed servers
+            return None
         q = self.query('/security/token?type=%s&scope=%s' % (type, scope))
         return q.attrib.get('token')
 
@@ -372,6 +383,36 @@ class PlexServer(PlexObject):
         """
         return self.fetchItem('/playlists', title=title)
 
+    def optimizedItems(self, removeAll=None):
+        """ Returns list of all :class:`~plexapi.media.Optimized` objects connected to server. """
+        if removeAll is True:
+            key = '/playlists/generators?type=42'
+            self.query(key, method=self._server._session.delete)
+        else:
+            backgroundProcessing = self.fetchItem('/playlists?type=42')
+            return self.fetchItems('%s/items' % backgroundProcessing.key, cls=Optimized)
+
+    def optimizedItem(self, optimizedID):
+        """ Returns single queued optimized item :class:`~plexapi.media.Video` object.
+            Allows for using optimized item ID to connect back to source item.
+        """
+
+        backgroundProcessing = self.fetchItem('/playlists?type=42')
+        return self.fetchItem('%s/items/%s/items' % (backgroundProcessing.key, optimizedID))
+
+    def conversions(self, pause=None):
+        """ Returns list of all :class:`~plexapi.media.Conversion` objects connected to server. """
+        if pause is True:
+            self.query('/:/prefs?BackgroundQueueIdlePaused=1', method=self._server._session.put)
+        elif pause is False:
+            self.query('/:/prefs?BackgroundQueueIdlePaused=0', method=self._server._session.put)
+        else:
+            return self.fetchItems('/playQueues/1', cls=Conversion)
+
+    def currentBackgroundProcess(self):
+        """ Returns list of all :class:`~plexapi.media.TranscodeJob` objects running or paused on server. """
+        return self.fetchItems('/status/sessions/background')
+
     def query(self, key, method=None, headers=None, timeout=None, **kwargs):
         """ Main method used to handle HTTPS requests to the Plex server. This method helps
             by encoding the response to utf-8 and parsing the returned XML into and
@@ -386,8 +427,13 @@ class PlexServer(PlexObject):
         if response.status_code not in (200, 201):
             codename = codes.get(response.status_code)[0]
             errtext = response.text.replace('\n', ' ')
-            log.warning('BadRequest (%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
-            raise BadRequest('(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext))
+            message = '(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext)
+            if response.status_code == 401:
+                raise Unauthorized(message)
+            elif response.status_code == 404:
+                raise NotFound(message)
+            else:
+                raise BadRequest(message)
         data = response.text.encode('utf8')
         return ElementTree.fromstring(data) if data.strip() else None
 
@@ -480,6 +526,25 @@ class PlexServer(PlexObject):
         """
         self.refreshSynclist()
         self.refreshContent()
+
+    def _allowMediaDeletion(self, toggle=False):
+        """ Toggle allowMediaDeletion.
+            Parameters:
+                toggle (bool): True enables Media Deletion
+                               False or None disable Media Deletion (Default)
+        """
+        if self.allowMediaDeletion and toggle is False:
+            log.debug('Plex is currently allowed to delete media. Toggling off.')
+        elif self.allowMediaDeletion and toggle is True:
+            log.debug('Plex is currently allowed to delete media. Toggle set to allow, exiting.')
+            raise BadRequest('Plex is currently allowed to delete media. Toggle set to allow, exiting.')
+        elif self.allowMediaDeletion is None and toggle is True:
+            log.debug('Plex is currently not allowed to delete media. Toggle set to allow.')
+        else:
+            log.debug('Plex is currently not allowed to delete media. Toggle set to not allow, exiting.')
+            raise BadRequest('Plex is currently not allowed to delete media. Toggle set to not allow, exiting.')
+        value = 1 if toggle is True else 0
+        return self.query('/:/prefs?allowMediaDeletion=%s' % value, self._session.put)
 
 
 class Account(PlexObject):

--- a/plexapi/settings.py
+++ b/plexapi/settings.py
@@ -124,8 +124,8 @@ class Setting(PlexObject):
         self.enumValues = self._getEnumValues(data)
 
     def _cast(self, value):
-        """ Cast the specifief value to the type of this setting. """
-        if self.type != 'text':
+        """ Cast the specific value to the type of this setting. """
+        if self.type != 'enum':
             value = utils.cast(self.TYPES.get(self.type)['cast'], value)
         return value
 

--- a/plexapi/sonos.py
+++ b/plexapi/sonos.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+import requests
+from plexapi import CONFIG, X_PLEX_IDENTIFIER
+from plexapi.client import PlexClient
+from plexapi.exceptions import BadRequest
+from plexapi.playqueue import PlayQueue
+
+
+class PlexSonosClient(PlexClient):
+    """ Class for interacting with a Sonos speaker via the Plex API. This class
+        makes requests to an external Plex API which then forwards the
+        Sonos-specific commands back to your Plex server & Sonos speakers. Use
+        of this feature requires an active Plex Pass subscription and Sonos
+        speakers linked to your Plex account. It also requires remote access to
+        be working properly.
+
+        More details on the Sonos integration are avaialble here:
+        https://support.plex.tv/articles/218237558-requirements-for-using-plex-for-sonos/
+
+        The Sonos API emulates the Plex player control API closely:
+        https://github.com/plexinc/plex-media-player/wiki/Remote-control-API
+
+        Parameters:
+            account (:class:`~plexapi.myplex.PlexAccount`): PlexAccount instance this
+                Sonos speaker is associated with.
+            data (ElementTree): Response from Plex Sonos API used to build this client.
+
+        Attributes:
+            deviceClass (str): "speaker"
+            lanIP (str): Local IP address of speaker.
+            machineIdentifier (str): Unique ID for this device.
+            platform (str): "Sonos"
+            platformVersion (str): Build version of Sonos speaker firmware.
+            product (str): "Sonos"
+            protocol (str): "plex"
+            protocolCapabilities (list<str>): List of client capabilities (timeline, playback,
+                playqueues, provider-playback)
+            server (:class:`~plexapi.server.PlexServer`): Server this client is connected to.
+            session (:class:`~requests.Session`): Session object used for connection.
+            title (str): Name of this Sonos speaker.
+            token (str): X-Plex-Token used for authenication
+            _baseurl (str): Address of public Plex Sonos API endpoint.
+            _commandId (int): Counter for commands sent to Plex API.
+            _token (str): Token associated with linked Plex account.
+            _session (obj): Requests session object used to access this client.
+    """
+
+    def __init__(self, account, data):
+        self._data = data
+        self.deviceClass = data.attrib.get("deviceClass")
+        self.machineIdentifier = data.attrib.get("machineIdentifier")
+        self.product = data.attrib.get("product")
+        self.platform = data.attrib.get("platform")
+        self.platformVersion = data.attrib.get("platformVersion")
+        self.protocol = data.attrib.get("protocol")
+        self.protocolCapabilities = data.attrib.get("protocolCapabilities")
+        self.lanIP = data.attrib.get("lanIP")
+        self.title = data.attrib.get("title")
+        self._baseurl = "https://sonos.plex.tv"
+        self._commandId = 0
+        self._token = account._token
+        self._session = account._session or requests.Session()
+
+        # Dummy values for PlexClient inheritance
+        self._last_call = 0
+        self._proxyThroughServer = False
+        self._showSecrets = CONFIG.get("log.show_secrets", "").lower() == "true"
+
+    def playMedia(self, media, offset=0, **params):
+
+        if hasattr(media, "playlistType"):
+            mediatype = media.playlistType
+        else:
+            if isinstance(media, PlayQueue):
+                mediatype = media.items[0].listType
+            else:
+                mediatype = media.listType
+
+        if mediatype == "audio":
+            mediatype = "music"
+        else:
+            raise BadRequest("Sonos currently only supports music for playback")
+
+        server_protocol, server_address, server_port = media._server._baseurl.split(":")
+        server_address = server_address.strip("/")
+        server_port = server_port.strip("/")
+
+        playqueue = (
+            media
+            if isinstance(media, PlayQueue)
+            else media._server.createPlayQueue(media)
+        )
+        self.sendCommand(
+            "playback/playMedia",
+            **dict(
+                {
+                    "type": "music",
+                    "providerIdentifier": "com.plexapp.plugins.library",
+                    "containerKey": "/playQueues/{}?own=1".format(
+                        playqueue.playQueueID
+                    ),
+                    "key": media.key,
+                    "offset": offset,
+                    "machineIdentifier": media._server.machineIdentifier,
+                    "protocol": server_protocol,
+                    "address": server_address,
+                    "port": server_port,
+                    "token": media._server.createToken(),
+                    "commandID": self._nextCommandId(),
+                    "X-Plex-Client-Identifier": X_PLEX_IDENTIFIER,
+                    "X-Plex-Token": media._server._token,
+                    "X-Plex-Target-Client-Identifier": self.machineIdentifier,
+                },
+                **params,
+            ),
+        )

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -7,11 +7,16 @@ import time
 import zipfile
 from datetime import datetime
 from getpass import getpass
-from threading import Thread, Event
-# Montellese: not needed
-# from tqdm import tqdm
+from threading import Event, Thread
+
+import requests
 from plexapi import compat
 from plexapi.exceptions import NotFound
+
+try:
+    from tqdm import tqdm
+except ImportError:
+    tqdm = None
 
 log = logging.getLogger('plexapi')
 
@@ -60,7 +65,7 @@ def registerPlexObject(cls):
 
 def cast(func, value):
     """ Cast the specified value to the specified type (returned by func). Currently this
-        only support int, float, bool. Should be extended if needed.
+        only support str, int, float, bool. Should be extended if needed.
 
         Parameters:
             func (func): Calback function to used cast to type (int, bool, float).
@@ -68,7 +73,13 @@ def cast(func, value):
     """
     if value is not None:
         if func == bool:
-            return bool(int(value))
+            if value in (1, True, "1", "true"):
+                return True
+            elif value in (0, False, "0", "false"):
+                return False
+            else:
+                raise ValueError(value)
+
         elif func in (int, float):
             try:
                 return func(value)
@@ -181,7 +192,7 @@ def toDatetime(value, format=None):
         if format:
             try:
                 value = datetime.strptime(value, format)
-            except ValueError:
+            except (ValueError, TypeError):  # mediaimport.plex patch to handle occasional TypeError
                 log.info('Failed to parse %s to datetime, defaulting to None', value)
                 return None
         else:
@@ -288,17 +299,17 @@ def download(url, token, filename=None, savepath=None, session=None, chunksize=4
 
     # save the file to disk
     log.info('Downloading: %s', fullpath)
-    if showstatus:  # pragma: no cover
+    if showstatus and tqdm:  # pragma: no cover
         total = int(response.headers.get('content-length', 0))
         bar = tqdm(unit='B', unit_scale=True, total=total, desc=filename)
 
     with open(fullpath, 'wb') as handle:
         for chunk in response.iter_content(chunk_size=chunksize):
             handle.write(chunk)
-            if showstatus:
+            if showstatus and tqdm:
                 bar.update(len(chunk))
 
-    if showstatus:  # pragma: no cover
+    if showstatus and tqdm:  # pragma: no cover
         bar.close()
     # check we want to unzip the contents
     if fullpath.endswith('zip') and unpack:
@@ -376,3 +387,15 @@ def choose(msg, items, attr):  # pragma: no cover
 
         except (ValueError, IndexError):
             pass
+
+
+def getAgentIdentifier(section, agent):
+    """ Return the full agent identifier from a short identifier, name, or confirm full identifier. """
+    agents = []
+    for ag in section.agents():
+        identifiers = [ag.identifier, ag.shortIdentifier, ag.name]
+        if agent in identifiers:
+            return ag.identifier
+        agents += identifiers
+    raise NotFound('Couldnt find "%s" in agents list (%s)' %
+                   (agent, ', '.join(agents)))

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -2,7 +2,7 @@
 from plexapi import media, utils
 from plexapi.exceptions import BadRequest, NotFound
 from plexapi.base import Playable, PlexPartialObject
-from plexapi.compat import quote_plus
+from plexapi.compat import quote_plus, urlencode
 import os
 
 
@@ -121,10 +121,81 @@ class Video(PlexPartialObject):
             if streamID == stream.id or streamTitle == stream.title:
                 self._server.query(stream.key, self._server._session.delete)
 
-    def posters(self):
-        """ Returns list of available poster objects. :class:`~plexapi.media.Poster`:"""
+    def optimize(self, title=None, target="", targetTagID=None, locationID=-1, policyScope='all',
+                 policyValue="", policyUnwatched=0, videoQuality=None, deviceProfile=None):
+        """ Optimize item
 
-        return self.fetchItems('%s/posters' % self.key, cls=media.Poster)
+            locationID (int): -1 in folder with orginal items
+                               2 library path
+
+            target (str): custom quality name.
+                          if none provided use "Custom: {deviceProfile}"
+
+            targetTagID (int):  Default quality settings
+                                1 Mobile
+                                2 TV
+                                3 Original Quality
+
+            deviceProfile (str): Android, IOS, Universal TV, Universal Mobile, Windows Phone,
+                                    Windows, Xbox One
+
+            Example:
+                Optimize for Mobile
+                   item.optimize(targetTagID="Mobile") or item.optimize(targetTagID=1")
+                Optimize for Android 10 MBPS 1080p
+                   item.optimize(deviceProfile="Android", videoQuality=10)
+                Optimize for IOS Original Quality
+                   item.optimize(deviceProfile="IOS", videoQuality=-1)
+
+            * see sync.py VIDEO_QUALITIES for additional information for using videoQuality
+        """
+        tagValues = [1, 2, 3]
+        tagKeys = ["Mobile", "TV", "Original Quality"]
+        tagIDs = tagKeys + tagValues
+
+        if targetTagID not in tagIDs and (deviceProfile is None or videoQuality is None):
+            raise BadRequest('Unexpected or missing quality profile.')
+
+        if isinstance(targetTagID, str):
+            tagIndex = tagKeys.index(targetTagID)
+            targetTagID = tagValues[tagIndex]
+
+        if title is None:
+            title = self.title
+
+        backgroundProcessing = self.fetchItem('/playlists?type=42')
+        key = '%s/items?' % backgroundProcessing.key
+        params = {
+            'Item[type]': 42,
+            'Item[target]': target,
+            'Item[targetTagID]': targetTagID if targetTagID else '',
+            'Item[locationID]': locationID,
+            'Item[Policy][scope]': policyScope,
+            'Item[Policy][value]': policyValue,
+            'Item[Policy][unwatched]': policyUnwatched
+        }
+
+        if deviceProfile:
+            params['Item[Device][profile]'] = deviceProfile
+
+        if videoQuality:
+            from plexapi.sync import MediaSettings
+            mediaSettings = MediaSettings.createVideo(videoQuality)
+            params['Item[MediaSettings][videoQuality]'] = mediaSettings.videoQuality
+            params['Item[MediaSettings][videoResolution]'] = mediaSettings.videoResolution
+            params['Item[MediaSettings][maxVideoBitrate]'] = mediaSettings.maxVideoBitrate
+            params['Item[MediaSettings][audioBoost]'] = ''
+            params['Item[MediaSettings][subtitleSize]'] = ''
+            params['Item[MediaSettings][musicBitrate]'] = ''
+            params['Item[MediaSettings][photoQuality]'] = ''
+
+        titleParam = {'Item[title]': title}
+        section = self._server.library.sectionByID(self.librarySectionID)
+        params['Item[Location][uri]'] = 'library://' + section.uuid + '/item/' + \
+                                        quote_plus(self.key + '?includeExternalMedia=1')
+
+        data = key + urlencode(params) + '&' + urlencode(titleParam)
+        return self._server.query(data, method=self._server._session.put)
 
     def sync(self, videoQuality, client=None, clientId=None, limit=None, unwatched=False, title=None):
         """ Add current video (movie, tv-show, season or episode) as sync item for specified device.
@@ -281,7 +352,7 @@ class Movie(Playable, Video):
             else:
                 self._server.url('%s?download=1' % location.key)
             filepath = utils.download(url, self._server._token, filename=name,
-                savepath=savepath, session=self._server._session)
+                                      savepath=savepath, session=self._server._session)
             if filepath:
                 filepaths.append(filepath)
         return filepaths
@@ -505,7 +576,7 @@ class Season(Video):
 
     def show(self):
         """ Return this seasons :func:`~plexapi.video.Show`.. """
-        return self.fetchItem(self.parentKey)
+        return self.fetchItem(int(self.parentRatingKey))
 
     def watched(self):
         """ Returns list of watched :class:`~plexapi.video.Episode` objects. """
@@ -646,8 +717,33 @@ class Episode(Playable, Video):
 
     def show(self):
         """" Return this episodes :func:`~plexapi.video.Show`.. """
-        return self.fetchItem(self.grandparentKey)
+        return self.fetchItem(int(self.grandparentRatingKey))
 
     def _defaultSyncTitle(self):
         """ Returns str, default title for a new syncItem. """
         return '%s - %s - (%s) %s' % (self.grandparentTitle, self.parentTitle, self.seasonEpisode, self.title)
+
+
+@utils.registerPlexObject
+class Clip(Playable, Video):
+    """ Represents a single Clip."""
+
+    TAG = 'Video'
+    TYPE = 'clip'
+    METADATA_TYPE = 'clip'
+
+    def _loadData(self, data):
+        self._data = data
+        self.addedAt = data.attrib.get('addedAt')
+        self.duration = data.attrib.get('duration')
+        self.guid = data.attrib.get('guid')
+        self.key = data.attrib.get('key')
+        self.originallyAvailableAt = data.attrib.get('originallyAvailableAt')
+        self.ratingKey = data.attrib.get('ratingKey')
+        self.skipDetails = utils.cast(int, data.attrib.get('skipDetails'))
+        self.subtype = data.attrib.get('subtype')
+        self.thumb = data.attrib.get('thumb')
+        self.thumbAspectRatio = data.attrib.get('thumbAspectRatio')
+        self.title = data.attrib.get('title')
+        self.type = data.attrib.get('type')
+        self.year = data.attrib.get('year')

--- a/resources/importsettings.xml
+++ b/resources/importsettings.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings version="1">
   <section id="import" label="32010">
+    <category id="sync" label="39530">
+      <group id="1">
+        <setting id="plex.forcesync" type="action" label="32022">
+          <level>0</level>
+          <control type="button" format="action" />
+        </setting>
+      </group>
+    </category>
     <category id="plex" label="32021">
       <group id="1">
         <setting id="plex.librarysections" type="list[string]" label="32020">
@@ -12,6 +20,14 @@
           <control type="list" format="string">
             <multiselect>true</multiselect>
           </control>
+        </setting>
+        <setting id="plex.syncsettingshash" type="string">
+          <visible>false</visible>
+          <level>4</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
         </setting>
       </group>
     </category>

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -92,6 +92,14 @@ msgctxt "#32021"
 msgid "Library"
 msgstr ""
 
+msgctxt "#32022"
+msgid "Force full synchronization"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Direct Play Settings"
+msgstr ""
+
 #. Titel of the dialog to select the authentication method
 msgctxt "#32050"
 msgid "Plex Media Server authentication method"
@@ -151,4 +159,8 @@ msgstr ""
 
 msgctxt "#32064"
 msgid "Unknown"
+msgstr ""
+
+msgctxt "#32065"
+msgid "Do you really want to force a full synchronization?"
 msgstr ""


### PR DESCRIPTION
### Main Changes
* Updated the local copy of plexapi to the latest release (3.5.0)
  * Made local patch to fix some still-existing bugs in the library
  * No need to make any import modification, so looks like we are good there
* Initially added pagination to then sync with control of the flow on our side, reverted but kept the change to the overall flow (build the ListItems in each section iteration instead of at the end), kept the container setting to make the plexapi lib paginate
  * Let me know if you want me to fully revert the flow change back to how you had it
* Updated local plexapi with ability to take a custom query string
  * Their implementation of query parameters only allows the '=' operation, this was easier than trying to rework that setup for now
* Updated import function to support fastSync
  * Currently the only check is if this is the first time syncing, then do full sync
  * Reviewed what you have going with Emby and most of it seemed emby-specific and not relevant here, but I didn't follow it all so let me know of any gaps
  * Left a comment and TODO in there to discuss what other checks we might need to do with you

### FastSync Notes

fastSync works like a charm. One of my libraries that takes about 1.5 hours to do initial import and around an hour to do synchronizations after that now finishes instantly when there are no changes, and within seconds to pick up typical changes.

The only gap I have found with the fastSync setup is that it does not detect if an item was changed from "watched" to "not watched" in plex. I couldn't find a way in the API get a delta query that would include those items. The way they store the data, the lastWatchedAt field just goes away when an item is marked unwatched and there is no other attribute that is updated to account for a change on the item.

I'm hoping we can rely on the websocket monitoring to deal with watched -> unwatched changes...?