### PR TITLE
added feature to tag all items with the id of the plex library

### DIFF
--- a/plex/api.py
+++ b/plex/api.py
@@ -502,7 +502,8 @@ class Api:
             'director': [],
             'writer': [],
             'genre': [],
-            'country': []
+            'country': [],
+            'tag': []
         }
 
         date = None
@@ -525,6 +526,7 @@ class Api:
                 'playcount': plexItem.viewCount,
                 'lastplayed': Api.convertDateTimeToDbDateTime(plexItem.lastViewedAt),
             })
+            info['tag'].append(plexItem.librarySectionTitle)
 
         if isinstance(plexItem, video.Movie):
             info.update({

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -35,6 +35,7 @@ class Video(PlexPartialObject):
         self.key = data.attrib.get('key', '')
         self.lastViewedAt = utils.toDatetime(data.attrib.get('lastViewedAt'))
         self.librarySectionID = data.attrib.get('librarySectionID')
+        self.librarySectionTitle = data.attrib.get('librarySectionTitle')  # mediaimporter.plex patch
         self.ratingKey = utils.cast(int, data.attrib.get('ratingKey'))
         self.summary = data.attrib.get('summary')
         self.thumb = data.attrib.get('thumb')


### PR DESCRIPTION
Quick feature to tag all video items with the PlexLibarary:<ID> that they come from.

Nice to have for use with Kodi skins that support library nodes to use the tag to separate items from the different plex libraries.

Was initially hoping to use 'path' for this but the stream URL for plex does not include any library identifiers, it's item specific.