### PR TITLE
Add support for direct play

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,8 @@
 - support fast (re-)synchronization (closes #10)
 - retrieve library items in batches of 100 items
 - add a setting to force full synchronization
-- add hte library name as a tag
+- add the library name as a tag
+- support direct play (closes #12)
 
 [B]Version 0.0.6[/B]
 - adjust kodi.mediaimporter extension point to changes in Kodi

--- a/lib/importer.py
+++ b/lib/importer.py
@@ -58,6 +58,7 @@ from lib.settings import SynchronizationSettings
 import plex
 from plex.api import Api
 from plex.server import Server
+from plex.constants import SETTINGS_PROVIDER_PLAYBACK_ALLOW_DIRECT_PLAY
 
 # general constants
 ITEM_REQUEST_LIMIT = 100
@@ -877,6 +878,9 @@ def execImport(handle: int, options: dict):
         log("cannot prepare provider settings", xbmc.LOGERROR)
         return
 
+    # get direct play settings from provider
+    allowDirectPlay = providerSettings.getBool(SETTINGS_PROVIDER_PLAYBACK_ALLOW_DIRECT_PLAY)
+
     # create a Plex Media Server instance
     server = Server(mediaProvider)
     plexServer = server.PlexServer()
@@ -1007,7 +1011,13 @@ def execImport(handle: int, options: dict):
                     sectionProgress += 1
 
                     try:
-                        item = Api.toFileItem(plexServer, plexItem, mediaType, plexLibType)
+                        item = Api.toFileItem(
+                            plexServer=plexServer,
+                            plexItem=plexItem,
+                            mediaType=mediaType,
+                            plexLibType=plexLibType,
+                            allowDirectPlay=allowDirectPlay
+                        )
                         if not item:
                             continue
 

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -13,7 +13,8 @@ from typing import List
 
 from plex.constants import (
     SETTINGS_IMPORT_SYNC_SETTINGS_HASH,
-    SETTINGS_IMPORT_LIBRARY_SECTIONS
+    SETTINGS_IMPORT_LIBRARY_SECTIONS,
+    SETTINGS_PROVIDER_PLAYBACK_ALLOW_DIRECT_PLAY,
 )
 
 import xbmcaddon
@@ -66,10 +67,15 @@ class SynchronizationSettings:
         if not importSettings:
             raise ValueError('invalid importSettings')
 
+        # provider settings
+        directPlayAllowed = providerSettings.getBool(SETTINGS_PROVIDER_PLAYBACK_ALLOW_DIRECT_PLAY)
+
         # import specific settings
         librarySections = importSettings.getStringList(SETTINGS_IMPORT_LIBRARY_SECTIONS)
 
         hashObject = {
+            # provider settings
+            SETTINGS_PROVIDER_PLAYBACK_ALLOW_DIRECT_PLAY: directPlayAllowed,
             # import specific settings
             SETTINGS_IMPORT_LIBRARY_SECTIONS: librarySections,
         }

--- a/plex/constants.py
+++ b/plex/constants.py
@@ -93,6 +93,7 @@ SETTINGS_PROVIDER_USERNAME = 'plex.username'
 SETTINGS_PROVIDER_TOKEN = 'plex.token'
 SETTINGS_PROVIDER_TEST_CONNECTION = 'plex.testconnection'
 SETTINGS_PROVIDER_PLAYBACK_ENABLE_EXTERNAL_SUBTITLES = 'plex.enableexternalsubtitles'
+SETTINGS_PROVIDER_PLAYBACK_ALLOW_DIRECT_PLAY = 'plex.allowdirectplay'
 
 # media import setting identifiers and values
 SETTINGS_IMPORT_LIBRARY_SECTIONS = 'plex.librarysections'

--- a/plex/provider_observer.py
+++ b/plex/provider_observer.py
@@ -37,6 +37,7 @@ class ProviderObserver:
         self._imports = []
         self._mediaProvider = None
         self._server = None
+        self._settings = None
 
         # create the websocket
         self._websocket = websocket.WebSocket()
@@ -461,7 +462,12 @@ class ProviderObserver:
         :return: ListItem object populated with the details of the plex item
         :rtype: :class:`xbmc.ListItem`
         """
-        return api.Api.getPlexItemAsListItem(self._server.PlexServer(), plexItemId, plexItemClass)
+        return api.Api.getPlexItemAsListItem(
+            self._server.PlexServer(),
+            plexItemId,
+            plexItemClass,
+            allowDirectPlay=self._settings.getBool(constants.SETTINGS_PROVIDER_PLAYBACK_ALLOW_DIRECT_PLAY)
+        )
 
     def _FindImportForItem(self, item: xbmcgui.ListItem) -> xbmcmediaimport.MediaImport:
         """Find a matching MediaImport in the imports list for the provided ListItem
@@ -503,8 +509,8 @@ class ProviderObserver:
 
         self._mediaProvider = mediaProvider
 
-        settings = self._mediaProvider.prepareSettings()
-        if not settings:
+        self._settings = self._mediaProvider.prepareSettings()
+        if not self._settings:
             raise RuntimeError('cannot prepare media provider settings')
 
         # create Plex server instance

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -164,3 +164,7 @@ msgstr ""
 msgctxt "#32065"
 msgid "Do you really want to force a full synchronization?"
 msgstr ""
+
+msgctxt "#32066"
+msgid "Allow using Direct Play"
+msgstr ""

--- a/resources/providersettings.xml
+++ b/resources/providersettings.xml
@@ -68,6 +68,11 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="plex.allowdirectplay" type="boolean" label="32066">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
   </section>


### PR DESCRIPTION
Update with direct play feature including settings:

* Enable/disable DirectPlayAllowed at the provider level
* Enable/disable path substitution at the import level
  * Source path to substitute
  * Substitution value

I threw a TODO [here](https://github.com/JeordyR/mediaimporter.plex/blob/efede4cc35e74584ea4e9eb19ce28e499d895001/plex/api.py#L391) to make sure we discussed this part.

I went through api, provider_observer, and observer and haven't had any luck figuring out how to get a mediaImport object to be able to pull in importSettings and providerSettings, or a way to get either of those without a mediaImport object at that point in the code.

I assume this will cause a gap where items added/updated via the websocket watcher will not end up getting the directPlay pathing that they should or having their directPlay pathing replaced with a stream URL if updating an existing item.

This setup is fully working with my server and test kodi setup with normal import. Using path substitution to replace `/data` with `smb://10.10.1.1/storage/media` to handle the pathing differences. Currently the DirectPlayAllowed provider settings is on by default, and fillVideoInfos will fall back to populating the streaming url if the direct_play pathing is not accessible. Wasn't sure if we would want the fall-back or throw an error if their direct_play config is wrong, so did the fall-back for now.